### PR TITLE
clean up GetCGameAPI

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -241,10 +241,11 @@ C_DLLEXPORT void* GetGameAPI(void* import) {
    It loads the DLL, calls the GetCGameAPI function with the same import pointer arg, then returns the return value of that
    function. It is a direct passing of pointers between the engine and CGame systems. After this function returns, there is no
    further interaction between QMM and the CGame system until this function is called again as a reload.
-
-   We may be able to find a way to integrate this better with the other cgame passthrough stuff that other games use.
 */
 C_DLLEXPORT void* GetCGameAPI(void* import) {
+#ifdef DEBUG_MESSAGEBOX
+	MessageBoxA(NULL, "GetCGameAPI called", "QMM2", 0);
+#endif
 	s_main_detect_env();
 
 	// ???
@@ -427,7 +428,7 @@ C_DLLEXPORT intptr_t vmMain(intptr_t cmd, ...) {
 			LOG(QMM_LOG_NOTICE, "QMM") << "Delaying shutting down mod so cgame shutdown can run\n";
 		}
 		else {
-			// unload mod (dlclose)
+			// unload mod
 			LOG(QMM_LOG_NOTICE, "QMM") << "Shutting down mod\n";
 			mod_unload(g_mod);
 		}


### PR DESCRIPTION
looked through the code paths. this might just be the simplest way to do it. other than this function, there's no further connection between engine, mod, and QMM related to CGame. the mod dll path-detecting code could better match s_main_load_mod but it's ok for now since it's just Q2R. i did add the debug messagebox code to GetCGameAPI, however.