### PR TITLE
Add better auto-detection functionality

### DIFF
--- a/include/game_api.h
+++ b/include/game_api.h
@@ -14,73 +14,110 @@ Created By:
 
 #include <cstdint>  // intptr_t
 #include <cstdarg>
-#include <vector>
-#include <string>
 #include "qmmapi.h"
 #include "qvm.h"
 
-// some information for each game engine supported by QMM
-struct supportedgame {
-    const char* dllname;					// default dll mod filename
-    const char* qvmname;					// default qvm mod filename (NULL = not supported)
-    const char* moddir;						// default moddir name
-    const char* gamename_long;				// long, descriptive, game name
-    std::vector<std::string> exe_hints;		// array of hints that should appear in the executable filename to be considered a game match
-
+struct supportedgame;
+struct supportedgame_funcs {
     // this section is made by GEN_INFO(GAME)
-    const char* gamename_short;				// short initials for game
-    int* qmm_eng_msgs;						// array of engine messages used by QMM
-    int* qmm_mod_msgs;						// array of mod messages used by QMM
-    const char*(*eng_msg_names)(intptr_t);	// pointer to a function that returns a string for a given engine message
-    const char*(*mod_msg_names)(intptr_t);	// pointer to a function that returns a string for a given mod message
+    int* qmm_eng_msgs;							// array of engine messages used by QMM
+    int* qmm_mod_msgs;							// array of mod messages used by QMM
+    const char* (*pfnEngMsgNames)(intptr_t);	// pointer to a function that returns a string for a given engine message
+    const char* (*pfnModMsgNames)(intptr_t);	// pointer to a function that returns a string for a given mod message
 
     // this section is made by GEN_DLLQVM(GAME), GEN_DLL(GAME), or GEN_GGA(GAME)
-    qvm_syscall pfnqvmsyscall;				// pointer to a function that handles mod->engine calls from a QVM (NULL = not supported)	
-    mod_dllEntry pfndllEntry;				// pointer to a function that handles dllEntry entry for a game (NULL = not supported)
-    mod_GetGameAPI pfnGetGameAPI;			// pointer to a function that handles GetGameAPI entry for a game (NULL = not supported)
-    bool(*pfnModLoad)(void*);				// pointer to a function that handles mod loading logic after a DLL is loaded
-    void(*pfnModUnload)();					// pointer to a function that handles mod unloading logic before a DLL is unloaded
+    bool(*pfnAutoDetect)(bool, supportedgame*);	// pointer to a function that handles auto-detection logic for a game (NULL = no auto-detection)
+    qvm_syscall pfnqvmsyscall;					// pointer to a function that handles mod->engine calls from a QVM (NULL = not supported)	
+    mod_dllEntry pfndllEntry;					// pointer to a function that handles dllEntry entry for a game (NULL = not supported)
+    mod_GetGameAPI pfnGetGameAPI;				// pointer to a function that handles GetGameAPI entry for a game (NULL = not supported)
+    bool(*pfnModLoad)(void*);					// pointer to a function that handles mod loading logic after a DLL is loaded
+    void(*pfnModUnload)();						// pointer to a function that handles mod unloading logic before a DLL is unloaded
+};
 
-    int max_syscall_args;					// max number of syscall args that this game needs (unused for now, but nice to have easily available)
-    int max_vmmain_args;					// max number of vmmain args that this game needs (unused for now, but nice to have easily available)
+// some information for each game engine supported by QMM
+struct supportedgame {
+    const char* dllname;			// default dll mod filename
+    const char* qvmname;			// default qvm mod filename (NULL = not supported)
+    const char* moddir;				// default moddir name
+    const char* gamename_long;		// long, descriptive, game name
+
+    // this section is made by GEN_FUNCS(GAME)
+    const char* gamename_short;		// short initials for game
+    supportedgame_funcs* funcs;     // function pointers for this game
+
+    int max_syscall_args;			// max number of syscall args that this game needs (unused for now, but nice to have easily available)
+    int max_vmmain_args;			// max number of vmmain args that this game needs (unused for now, but nice to have easily available)
 };
 
 extern supportedgame g_supportedgames[];
 
 // macros to make game support a bit easier to do
-// these macros are used in game_api.cpp and game_xyz.cpp
 
-// generate externs for each game's msg arrays and functions
-#define GEN_EXTS(game)		extern int game##_qmm_eng_msgs[]; \
-							extern int game##_qmm_mod_msgs[]; \
-							const char* game##_eng_msg_names(intptr_t); \
-							const char* game##_mod_msg_names(intptr_t); \
-							int game##_qvmsyscall(uint8_t*, int, int*); \
-							void game##_dllEntry(eng_syscall); \
-							void* game##_GetGameAPI(void*, void*); \
-							bool game##_mod_load(void*); \
-							void game##_mod_unload();
+// used at the top of game_api.cpp and game_XYZ.cpp
+// ======
+// generate extern for each game's functions
+#define GEN_EXTS(game)	extern supportedgame_funcs game##_funcs;
 
-// generate struct info for the short name, messages arrays, and message name functions
-#define GEN_INFO(game)		#game, game##_qmm_eng_msgs, game##_qmm_mod_msgs, game##_eng_msg_names, game##_mod_msg_names
+// used in supportedgames entry in game_api.cpp
+// ======
+// generate extern for each game's shortcode and supportedgame_funcs struct (used in game_api.cpp)
+#define GEN_INFO(game)  #game , &game##_funcs
 
-// generate struct info for the game-specific entry functions
+// used in game_XYZ.cpp
+// ======
+// generate struct info for the game-specific functions and arrays
 
 // dllEntry/vmMain game with QVM support
-#define GEN_DLLQVM(game)	game##_qvmsyscall, game##_dllEntry, nullptr, game##_mod_load, game##_mod_unload
+#define GEN_DLLQVM(game) \
+static const char* game##_eng_msg_names(intptr_t); \
+static const char* game##_mod_msg_names(intptr_t); \
+static bool game##_autodetect(bool, supportedgame*); \
+static intptr_t game##_syscall(intptr_t cmd, ...); \
+static intptr_t game##_vmMain(intptr_t cmd, ...); \
+static int game##_qvmsyscall(uint8_t*, int, int*); \
+static void game##_dllEntry(eng_syscall); \
+static bool game##_mod_load(void*); \
+static void game##_mod_unload(); \
+supportedgame_funcs game##_funcs = { \
+	game##_qmm_eng_msgs, game##_qmm_mod_msgs, game##_eng_msg_names, game##_mod_msg_names, \
+	game##_autodetect, game##_qvmsyscall, game##_dllEntry, nullptr, \
+	game##_mod_load, game##_mod_unload \
+}
+
 // dllEntry/vmMain game with no QVM support
-#define GEN_DLL(game)		nullptr, game##_dllEntry, nullptr, game##_mod_load, game##_mod_unload
+#define GEN_DLL(game) \
+static const char* game##_eng_msg_names(intptr_t); \
+static const char* game##_mod_msg_names(intptr_t); \
+static bool game##_autodetect(bool, supportedgame*); \
+static intptr_t game##_syscall(intptr_t cmd, ...); \
+static intptr_t game##_vmMain(intptr_t cmd, ...); \
+static void game##_dllEntry(eng_syscall); \
+static bool game##_mod_load(void*); \
+static void game##_mod_unload(); \
+supportedgame_funcs game##_funcs = { \
+	game##_qmm_eng_msgs, game##_qmm_mod_msgs, game##_eng_msg_names, game##_mod_msg_names, \
+	game##_autodetect, nullptr, game##_dllEntry, nullptr, \
+	game##_mod_load, game##_mod_unload \
+}
+
 // GetGameAPI game
-#define GEN_GGA(game)		nullptr, nullptr, game##_GetGameAPI, game##_mod_load, game##_mod_unload
+#define GEN_GGA(game) \
+static const char* game##_eng_msg_names(intptr_t); \
+static const char* game##_mod_msg_names(intptr_t); \
+static bool game##_autodetect(bool, supportedgame*); \
+static intptr_t game##_syscall(intptr_t cmd, ...); \
+static intptr_t game##_vmMain(intptr_t cmd, ...); \
+static void* game##_GetGameAPI(void*, void*); \
+static bool game##_mod_load(void*); \
+static void game##_mod_unload(); \
+supportedgame_funcs game##_funcs = { \
+	game##_qmm_eng_msgs, game##_qmm_mod_msgs, game##_eng_msg_names, game##_mod_msg_names, \
+	game##_autodetect, nullptr, nullptr, game##_GetGameAPI, \
+	game##_mod_load, game##_mod_unload \
+}
 
-// only for development/testing new game support
-// dllEntry/vmMain game with QVM support and no modload/modunload, dllentry, or syscall/vmmain handlers
-#define GEN_QVM(game)		game##_qvmsyscall, nullptr, nullptr, nullptr, nullptr
-// dllEntry/vmMain game with no QVM support and no modload/modunload, dllentry, or syscall/vmmain handlers
-#define GEN_NONE(game)		nullptr, nullptr, nullptr, nullptr, nullptr
-
-// generate a case/string line for the message name functions
-#define GEN_CASE(x)			case x: return #x
+// generate a case/string line for use in the _msg_names functions
+#define GEN_CASE(x)				case x: return #x
 
 // a list of all the engine messages/constants used by QMM. if you change this, update the GEN_QMM_MSGS macro
 enum {
@@ -97,12 +134,12 @@ enum { QMM_GAME_INIT, QMM_GAME_SHUTDOWN, QMM_GAME_CONSOLE_COMMAND, };
 
 // macro to easily output game-specific message values to match the enums above. this macro goes in game_*.cpp
 #define GEN_QMM_MSGS(game) \
-	int game##_qmm_eng_msgs[] = { \
+	static int game##_qmm_eng_msgs[] = { \
 		G_PRINT, G_ERROR, G_ARGV, G_ARGC, G_SEND_CONSOLE_COMMAND, G_GET_CONFIGSTRING, \
 		G_CVAR_REGISTER, G_CVAR_VARIABLE_STRING_BUFFER, G_CVAR_VARIABLE_INTEGER_VALUE, CVAR_SERVERINFO, CVAR_ROM, \
 		G_FS_FOPEN_FILE, G_FS_READ, G_FS_WRITE, G_FS_FCLOSE_FILE, EXEC_APPEND, FS_READ, \
 	}; \
-	int game##_qmm_mod_msgs[] = { \
+	static int game##_qmm_mod_msgs[] = { \
 		GAME_INIT, GAME_SHUTDOWN, GAME_CONSOLE_COMMAND, \
 	}
 

--- a/include/main.h
+++ b/include/main.h
@@ -36,8 +36,8 @@ struct gameinfo {
 };
 extern gameinfo g_gameinfo;
 
-#define QMM_ENG_MSG	(g_gameinfo.game->qmm_eng_msgs)
-#define QMM_MOD_MSG	(g_gameinfo.game->qmm_mod_msgs)
+#define QMM_ENG_MSG	(g_gameinfo.game->funcs->qmm_eng_msgs)
+#define QMM_MOD_MSG	(g_gameinfo.game->funcs->qmm_mod_msgs)
 
 #define ENG_SYSCALL	(g_gameinfo.pfnsyscall)
 #define CONSOLE_PRINT(str)           ENG_SYSCALL(msg_G_PRINT, str)

--- a/include/util.h
+++ b/include/util.h
@@ -32,7 +32,7 @@ void path_mkdir(std::string path);
 
 std::string str_tolower(std::string str);
 std::string str_toupper(std::string str);
-int str_stristr(std::string haystack, std::string needle);
+bool str_stristr(std::string haystack, std::string needle);
 int str_stricmp(std::string s1, std::string s2);
 int str_striequal(std::string s1, std::string s2);
 

--- a/src/game_api.cpp
+++ b/src/game_api.cpp
@@ -42,49 +42,49 @@ GEN_EXTS(STVOYSP);
 
 // add your game's info data here
 supportedgame g_supportedgames[] = {
-    // mod filename		    qvm mod filename	default moddir	full gamename									exe hints               msgs/short name		entry procs		    #syscall#vmmain
+    // mod filename		    qvm mod filename	default moddir	full gamename									short name/funcs	#syscall#vmmain
 
     // vmMain games
-	{ "qagame" MOD_DLL,		"vm/qagame.qvm",	"baseq3",		"Quake 3 Arena",								{ "q3", "quake3" },		GEN_INFO(Q3A),		GEN_DLLQVM(Q3A),	13,		4 },
-	{ "qagame" MOD_DLL,		"vm/qagame.qvm",	"baseef",		"Star Trek Voyager: Elite Force (Holomatch)",	{ "stvoy" },			GEN_INFO(STVOYHM),	GEN_DLLQVM(STVOYHM),13,		3 },
-	{ "qagame" MOD_DLL,		nullptr,			".",			"Return to Castle Wolfenstein (SP)",			{ "sp" },				GEN_INFO(RTCWSP),	GEN_DLL(RTCWSP),	13,		5 },
-	{ "jk2mpgame" MOD_DLL,	"vm/jk2mpgame.qvm",	"base",			"Jedi Knight 2: Jedi Outcast (MP)",				{ "jk2" },				GEN_INFO(JK2MP),	GEN_DLLQVM(JK2MP),	13,		3 },
-	{ "sof2mp_game" MOD_DLL,"vm/sof2mp_game.qvm","base/mp",		"Soldier of Fortune 2: Double Helix (MP)",		{ "mp" },				GEN_INFO(SOF2MP),	GEN_DLLQVM(SOF2MP),	13,		6 },
-	{ "jampgame" MOD_DLL,	nullptr,			"base",			"Jedi Knight: Jedi Academy (MP)",				{ "ja" },				GEN_INFO(JAMP),		GEN_DLL(JAMP),		13,		6 },
+	{ "qagame" MOD_DLL,		"vm/qagame.qvm",	"baseq3",		"Quake 3 Arena",								GEN_INFO(Q3A),		13,		4 },
+	{ "qagame" MOD_DLL,		"vm/qagame.qvm",	"baseef",		"Star Trek Voyager: Elite Force (Holomatch)",	GEN_INFO(STVOYHM),	13,		3 },
+	{ "qagame" MOD_DLL,		nullptr,			".",			"Return to Castle Wolfenstein (SP)",			GEN_INFO(RTCWSP),	13,		5 },
+	{ "jk2mpgame" MOD_DLL,	"vm/jk2mpgame.qvm",	"base",			"Jedi Knight 2: Jedi Outcast (MP)",				GEN_INFO(JK2MP),	13,		3 },
+	{ "sof2mp_game" MOD_DLL,"vm/sof2mp_game.qvm","base/mp",		"Soldier of Fortune 2: Double Helix (MP)",		GEN_INFO(SOF2MP),	13,		6 },
+	{ "jampgame" MOD_DLL,	nullptr,			"base",			"Jedi Knight: Jedi Academy (MP)",				GEN_INFO(JAMP),		13,		6 },
 	// COD, RTCWMP & WET filename changes on linux
 #if defined(_WIN32)
-	{ "qagame_mp_" MOD_DLL,	nullptr,			"etmain",		"Wolfenstein: Enemy Territory",					{ "et" },				GEN_INFO(WET),		GEN_DLL(WET),		13,		5 },
-	{ "qagame_mp_" MOD_DLL,	nullptr,			"main",			"Return to Castle Wolfenstein (MP)",			{ "mp" },				GEN_INFO(RTCWMP),	GEN_DLL(RTCWMP),	13,		5 },
-	{ "game_mp_" MOD_DLL,	nullptr,			"Main",			"Call of Duty (MP)",							{ "codmp", "cod_" },	GEN_INFO(CODMP),	GEN_DLL(CODMP),		8,		4 },
-	{ "uo_game_mp_" MOD_DLL,nullptr,			"uo",			"Call of Duty: United Offensive (MP)",			{ "coduo" },			GEN_INFO(CODUOMP),	GEN_DLL(CODUOMP),	8,		4 },
-	// allow a user to choose "COD11MP" manually if they are playing an old version of CoD (fake exe hints so it won't auto-detect)
-	{ "game_mp_" MOD_DLL,	nullptr,			"Main",			"Call of Duty v1.1 (MP)",						{ "zzz_no_auto" },		GEN_INFO(COD11MP),	GEN_DLL(COD11MP),	8,		4 },
+	{ "qagame_mp_" MOD_DLL,	nullptr,			"etmain",		"Wolfenstein: Enemy Territory",					GEN_INFO(WET),		13,		5 },
+	{ "qagame_mp_" MOD_DLL,	nullptr,			"main",			"Return to Castle Wolfenstein (MP)",			GEN_INFO(RTCWMP),	13,		5 },
+	{ "game_mp_" MOD_DLL,	nullptr,			"Main",			"Call of Duty (MP)",							GEN_INFO(CODMP),	8,		4 },
+	{ "uo_game_mp_" MOD_DLL,nullptr,			"uo",			"Call of Duty: United Offensive (MP)",			GEN_INFO(CODUOMP),	8,		4 },
+	// allow a user to choose "COD11MP" manually if they are playing an old version of CoD (no auto-detection)
+	{ "game_mp_" MOD_DLL,	nullptr,			"Main",			"Call of Duty v1.1 (MP)",						GEN_INFO(COD11MP),	8,		4 },
 #elif defined(__linux__)
-	{ "qagame.mp." MOD_DLL,	nullptr,			"etmain",		"Wolfenstein: Enemy Territory",					{ "et" },				GEN_INFO(WET),		GEN_DLL(WET),		13,		5 },
-	{ "qagame.mp." MOD_DLL,	nullptr,			"main",			"Return to Castle Wolfenstein (MP)",			{ "mp" },				GEN_INFO(RTCWMP),	GEN_DLL(RTCWMP),	13,		5 },
-	{ "game.mp." MOD_DLL,	nullptr,			"Main",			"Call of Duty (MP)",							{ "codmp", "cod_" },	GEN_INFO(CODMP),	GEN_DLL(CODMP),		8,		4 },
-	{ "game.mp.uo." MOD_DLL,nullptr,			"uo",			"Call of Duty: United Offensive (MP)",			{ "coduo" },			GEN_INFO(CODUOMP),	GEN_DLL(CODUOMP),	8,		4 },
-	// allow a user to choose "COD11MP" manually if they are playing an old version of CoD (fake exe hints so it won't auto-detect)
-	{ "game.mp." MOD_DLL,	nullptr,			"Main",			"Call of Duty v1.1 (MP)",						{ "zzz_no_auto" },		GEN_INFO(COD11MP),	GEN_DLL(COD11MP),	8,		4 },
+	{ "qagame.mp." MOD_DLL,	nullptr,			"etmain",		"Wolfenstein: Enemy Territory",					GEN_INFO(WET),		13,		5 },
+	{ "qagame.mp." MOD_DLL,	nullptr,			"main",			"Return to Castle Wolfenstein (MP)",			GEN_INFO(RTCWMP),	13,		5 },
+	{ "game.mp." MOD_DLL,	nullptr,			"Main",			"Call of Duty (MP)",							GEN_INFO(CODMP),	8,		4 },
+	{ "game.mp.uo." MOD_DLL,nullptr,			"uo",			"Call of Duty: United Offensive (MP)",			GEN_INFO(CODUOMP),	8,		4 },
+	// allow a user to choose "COD11MP" manually if they are playing an old version of CoD (no auto-detection)
+	{ "game.mp." MOD_DLL,	nullptr,			"Main",			"Call of Duty v1.1 (MP)",						GEN_INFO(COD11MP),	8,		4 },
 #endif
 
 	// GetGameAPI games
-	{ "game" MOD_DLL,		nullptr,			"baseq2",		"Quake 2",										{ "q2", "quake2" },		GEN_INFO(QUAKE2),	GEN_GGA(QUAKE2),	7,		3 },
-	{ "game" MOD_DLL,		nullptr,			"base",			"Star Trek: Elite Force II",					{ "ef" },				GEN_INFO(STEF2),	GEN_GGA(STEF2),		17,		4 },
-	{ "game" MOD_DLL,		nullptr,			"base",			"SiN",											{ "sin" },				GEN_INFO(SIN),		GEN_GGA(SIN),		10,		3 },
-	{ "game" MOD_DLL,		nullptr,			".",			"Soldier of Fortune 2: Double Helix (SP)",		{ "sof2" },				GEN_INFO(SOF2SP),	GEN_GGA(SOF2SP),	-1,		-1 },
+	{ "game" MOD_DLL,		nullptr,			"baseq2",		"Quake 2",										GEN_INFO(QUAKE2),	7,		3 },
+	{ "game" MOD_DLL,		nullptr,			"base",			"Star Trek: Elite Force II",					GEN_INFO(STEF2),	17,		4 },
+	{ "game" MOD_DLL,		nullptr,			"base",			"SiN",											GEN_INFO(SIN),		10,		3 },
+	{ "game" MOD_DLL,		nullptr,			".",			"Soldier of Fortune 2: Double Helix (SP)",		GEN_INFO(SOF2SP),	-1,		-1 },
 // OpenMOHAA adds 64-bit MoH support but the API is very different, so disable it for now
 #if !defined(_WIN64) && !defined(__LP64__)
-	{ "game" MOD_DLL,		nullptr,			"main",			"Medal of Honor: Allied Assault",				{ "mohaa" },			GEN_INFO(MOHAA),	GEN_GGA(MOHAA), 	9,		7 },
-	{ "game" MOD_DLL,		nullptr,			"mainta",		"Medal of Honor: Spearhead",					{ "spear" },			GEN_INFO(MOHSH),	GEN_GGA(MOHSH),		9,		7 },
-	{ "game" MOD_DLL,		nullptr,			"maintt",		"Medal of Honor: Breakthrough",					{ "break" },			GEN_INFO(MOHBT),	GEN_GGA(MOHBT),		9,		7 },
+	{ "game" MOD_DLL,		nullptr,			"main",			"Medal of Honor: Allied Assault",				GEN_INFO(MOHAA),	9,		7 },
+	{ "game" MOD_DLL,		nullptr,			"mainta",		"Medal of Honor: Spearhead",					GEN_INFO(MOHSH),	9,		7 },
+	{ "game" MOD_DLL,		nullptr,			"maintt",		"Medal of Honor: Breakthrough",					GEN_INFO(MOHBT),	9,		7 },
 #endif
-	{ "jk2game" MOD_DLL,	nullptr,			".",			"Jedi Knight 2: Jedi Outcast (SP)",				{ "jk2" },				GEN_INFO(JK2SP),	GEN_GGA(JK2SP),		13,		9 },
-	{ "jagame" MOD_DLL,		nullptr,			".",			"Jedi Knight: Jedi Academy (SP)",				{ "ja" },				GEN_INFO(JASP),		GEN_GGA(JASP),		13,		9 },
-	{ "efgame" MOD_DLL,		nullptr,			".",			"Star Trek Voyager: Elite Force (SP)",			{ "stvoy" },			GEN_INFO(STVOYSP),	GEN_GGA(STVOYSP),	13,		9 },
+	{ "jk2game" MOD_DLL,	nullptr,			".",			"Jedi Knight 2: Jedi Outcast (SP)",				GEN_INFO(JK2SP),	13,		9},
+	{ "jagame" MOD_DLL,		nullptr,			".",			"Jedi Knight: Jedi Academy (SP)",				GEN_INFO(JASP),		13,		9},
+	{ "efgame" MOD_DLL,		nullptr,			".",			"Star Trek Voyager: Elite Force (SP)",			GEN_INFO(STVOYSP),	13,		9 },
 	// Q2R only exists for 64-bit Windows (and no dedicated server)
 #if defined(_WIN64)
-	{ "game_x64.dll",		nullptr,			"baseq2",		"Quake 2 Remastered",							{ "quake2ex" },			GEN_INFO(Q2R),		GEN_GGA(Q2R),		9,		6 },
+	{ "game_x64.dll",		nullptr,			"baseq2",		"Quake 2 Remastered",							GEN_INFO(Q2R),		9,		6 },
 #endif
 
 	{ nullptr, }

--- a/src/game_cod11mp.cpp
+++ b/src/game_cod11mp.cpp
@@ -16,10 +16,28 @@ Created By:
 // QMM-specific COD11MP header
 #include "game_cod11mp.h"
 #include "main.h"
-#include "mod.h"
 
 GEN_QMM_MSGS(COD11MP);
 GEN_EXTS(COD11MP);
+
+static const char* COD11MP_eng_msg_names(intptr_t);
+static const char* COD11MP_mod_msg_names(intptr_t);
+static void COD11MP_dllEntry(eng_syscall);
+static bool COD11MP_mod_load(void*);
+static void COD11MP_mod_unload();
+supportedgame_funcs COD11MP_funcs = {
+    COD11MP_qmm_eng_msgs,
+    COD11MP_qmm_mod_msgs,
+    COD11MP_eng_msg_names,
+    COD11MP_mod_msg_names,
+    nullptr, // COD11MP_autodetect
+    nullptr, // COD11MP_qvmsyscall
+    COD11MP_dllEntry,
+    nullptr, // COD11MP_GetGameAPI
+    COD11MP_mod_load,
+    COD11MP_mod_unload
+};
+
 
 // original syscall pointer that comes from the game engine
 static eng_syscall orig_syscall = nullptr;
@@ -29,7 +47,7 @@ static mod_vmMain orig_vmMain = nullptr;
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t COD11MP_syscall(intptr_t cmd, ...) {
+static intptr_t COD11MP_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -76,7 +94,7 @@ intptr_t COD11MP_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t COD11MP_vmMain(intptr_t cmd, ...) {
+static intptr_t COD11MP_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -100,7 +118,7 @@ intptr_t COD11MP_vmMain(intptr_t cmd, ...) {
 }
 
 
-void COD11MP_dllEntry(eng_syscall syscall) {
+static void COD11MP_dllEntry(eng_syscall syscall) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("COD11MP_dllEntry({}) called\n", (void*)syscall);
 
     // store original syscall from engine
@@ -116,19 +134,19 @@ void COD11MP_dllEntry(eng_syscall syscall) {
 }
 
 
-bool COD11MP_mod_load(void* entry) {
+static bool COD11MP_mod_load(void* entry) {
     orig_vmMain = (mod_vmMain)entry;
 
     return !!orig_vmMain;
 }
 
 
-void COD11MP_mod_unload() {
+static void COD11MP_mod_unload() {
     orig_vmMain = nullptr;
 }
 
 
-const char* COD11MP_eng_msg_names(intptr_t cmd) {
+static const char* COD11MP_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_PRINTF);
         GEN_CASE(G_ERROR);
@@ -275,7 +293,7 @@ const char* COD11MP_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* COD11MP_mod_msg_names(intptr_t cmd) {
+static const char* COD11MP_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAME_INIT);
         GEN_CASE(GAME_SHUTDOWN);

--- a/src/game_codmp.cpp
+++ b/src/game_codmp.cpp
@@ -16,7 +16,7 @@ Created By:
 // QMM-specific CODMP header
 #include "game_codmp.h"
 #include "main.h"
-#include "mod.h"
+#include "util.h"
 
 // GAME_GET_APIVERSION gets called first, which is when QMM has to perform mod/plugin loading, but we
 // don't want to make plugins have to use separate code to handle the actual GAME_INIT message, so just
@@ -26,6 +26,24 @@ GEN_QMM_MSGS(CODMP);
 #undef GAME_INIT
 GEN_EXTS(CODMP);
 
+GEN_DLL(CODMP);
+
+
+// auto-detection logic for CODMP
+static bool CODMP_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "codmp") && !str_stristr(g_gameinfo.exe_file, "cod_lnxded"))
+        return false;
+
+    return true;
+}
+
+
 // original syscall pointer that comes from the game engine
 static eng_syscall orig_syscall = nullptr;
 
@@ -34,7 +52,7 @@ static mod_vmMain orig_vmMain = nullptr;
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t CODMP_syscall(intptr_t cmd, ...) {
+static intptr_t CODMP_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -81,7 +99,7 @@ intptr_t CODMP_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t CODMP_vmMain(intptr_t cmd, ...) {
+static intptr_t CODMP_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -105,7 +123,7 @@ intptr_t CODMP_vmMain(intptr_t cmd, ...) {
 }
 
 
-void CODMP_dllEntry(eng_syscall syscall) {
+static void CODMP_dllEntry(eng_syscall syscall) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("CODMP_dllEntry({}) called\n", (void*)syscall);
 
     // store original syscall from engine
@@ -121,19 +139,19 @@ void CODMP_dllEntry(eng_syscall syscall) {
 }
 
 
-bool CODMP_mod_load(void* entry) {
+static bool CODMP_mod_load(void* entry) {
     orig_vmMain = (mod_vmMain)entry;
 
     return !!orig_vmMain;
 }
 
 
-void CODMP_mod_unload() {
+static void CODMP_mod_unload() {
     orig_vmMain = nullptr;
 }
 
 
-const char* CODMP_eng_msg_names(intptr_t cmd) {
+static const char* CODMP_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_PRINTF);
         GEN_CASE(G_ERROR);
@@ -285,7 +303,7 @@ const char* CODMP_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* CODMP_mod_msg_names(intptr_t cmd) {
+static const char* CODMP_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAME_DEFAULT_0);
         GEN_CASE(GAME_GET_APIVERSION);

--- a/src/game_coduomp.cpp
+++ b/src/game_coduomp.cpp
@@ -16,7 +16,7 @@ Created By:
 // QMM-specific CODUOMP header
 #include "game_coduomp.h"
 #include "main.h"
-#include "mod.h"
+#include "util.h"
 
 // GAME_GET_APIVERSION gets called first, which is when QMM has to perform mod/plugin loading, but we
 // don't want to make plugins have to use separate code to handle the actual GAME_INIT message, so just
@@ -26,6 +26,24 @@ GEN_QMM_MSGS(CODUOMP);
 #undef GAME_INIT
 GEN_EXTS(CODUOMP);
 
+GEN_DLL(CODUOMP);
+
+
+// auto-detection logic for CODUOMP
+static bool CODUOMP_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "coduomp") && !str_stristr(g_gameinfo.exe_file, "coduo_lnxded"))
+        return false;
+
+    return true;
+}
+
+
 // original syscall pointer that comes from the game engine
 static eng_syscall orig_syscall = nullptr;
 
@@ -34,7 +52,7 @@ static mod_vmMain orig_vmMain = nullptr;
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t CODUOMP_syscall(intptr_t cmd, ...) {
+static intptr_t CODUOMP_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -81,7 +99,7 @@ intptr_t CODUOMP_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t CODUOMP_vmMain(intptr_t cmd, ...) {
+static intptr_t CODUOMP_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -105,7 +123,7 @@ intptr_t CODUOMP_vmMain(intptr_t cmd, ...) {
 }
 
 
-void CODUOMP_dllEntry(eng_syscall syscall) {
+static void CODUOMP_dllEntry(eng_syscall syscall) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("CODUOMP_dllEntry({}) called\n", (void*)syscall);
 
     // store original syscall from engine
@@ -121,19 +139,19 @@ void CODUOMP_dllEntry(eng_syscall syscall) {
 }
 
 
-bool CODUOMP_mod_load(void* entry) {
+static bool CODUOMP_mod_load(void* entry) {
     orig_vmMain = (mod_vmMain)entry;
 
     return !!orig_vmMain;
 }
 
 
-void CODUOMP_mod_unload() {
+static void CODUOMP_mod_unload() {
     orig_vmMain = nullptr;
 }
 
 
-const char* CODUOMP_eng_msg_names(intptr_t cmd) {
+static const char* CODUOMP_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_PRINTF);
         GEN_CASE(G_ERROR);
@@ -285,7 +303,7 @@ const char* CODUOMP_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* CODUOMP_mod_msg_names(intptr_t cmd) {
+static const char* CODUOMP_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAME_DEFAULT_0);
         GEN_CASE(GAME_GET_APIVERSION);

--- a/src/game_jamp.cpp
+++ b/src/game_jamp.cpp
@@ -17,10 +17,31 @@ Created By:
 // QMM-specific JAMP header
 #include "game_jamp.h"
 #include "main.h"
-#include "mod.h"
+#include "util.h"
 
 GEN_QMM_MSGS(JAMP);
 GEN_EXTS(JAMP);
+
+GEN_DLL(JAMP);
+
+
+// auto-detection logic for JAMP
+static bool JAMP_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (is_GetGameAPI)
+        return false;
+
+    // QMM filename must match default or an OpenJK temp filename (if DLL was pulled from .pk3)
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname)
+        && !str_striequal(g_gameinfo.qmm_file.substr(0, 3), "ojk")
+        && !str_striequal(path_baseext(g_gameinfo.qmm_file), "tmp"))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "jamp") && !str_stristr(g_gameinfo.exe_file, "openjk.") && !str_stristr(g_gameinfo.exe_file, "openjkded"))
+        return false;
+
+    return true;
+}
+
 
 // original syscall pointer that comes from the game engine
 static eng_syscall orig_syscall = nullptr;
@@ -30,7 +51,7 @@ static mod_vmMain orig_vmMain = nullptr;
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t JAMP_syscall(intptr_t cmd, ...) {
+static intptr_t JAMP_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -77,7 +98,7 @@ intptr_t JAMP_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t JAMP_vmMain(intptr_t cmd, ...) {
+static intptr_t JAMP_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -101,7 +122,7 @@ intptr_t JAMP_vmMain(intptr_t cmd, ...) {
 }
 
 
-void JAMP_dllEntry(eng_syscall syscall) {
+static void JAMP_dllEntry(eng_syscall syscall) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("JAMP_dllEntry({}) called\n", (void*)syscall);
 
     // store original syscall from engine
@@ -117,19 +138,19 @@ void JAMP_dllEntry(eng_syscall syscall) {
 }
 
 
-bool JAMP_mod_load(void* entry) {
+static bool JAMP_mod_load(void* entry) {
     orig_vmMain = (mod_vmMain)entry;
 
     return !!orig_vmMain;
 }
 
 
-void JAMP_mod_unload() {
+static void JAMP_mod_unload() {
     orig_vmMain = nullptr;
 }
 
 
-const char* JAMP_eng_msg_names(intptr_t cmd) {
+static const char* JAMP_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_PRINT);
         GEN_CASE(G_ERROR);
@@ -467,7 +488,7 @@ const char* JAMP_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* JAMP_mod_msg_names(intptr_t cmd) {
+static const char* JAMP_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAME_INIT);
         GEN_CASE(GAME_SHUTDOWN);

--- a/src/game_jasp.cpp
+++ b/src/game_jasp.cpp
@@ -22,6 +22,24 @@ Created By:
 GEN_QMM_MSGS(JASP);
 GEN_EXTS(JASP);
 
+GEN_GGA(JASP);
+
+
+// auto-detection logic for JASP
+static bool JASP_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (!is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "jasp") && !str_stristr(g_gameinfo.exe_file, "openjk_sp"))
+        return false;
+
+    return true;
+}
+
+
 // a copy of the original import struct that comes from the game engine
 static game_import_t orig_import;
 
@@ -236,7 +254,7 @@ static void s_update_export() {
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t JASP_syscall(intptr_t cmd, ...) {
+static intptr_t JASP_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -480,7 +498,7 @@ intptr_t JASP_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t JASP_vmMain(intptr_t cmd, ...) {
+static intptr_t JASP_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -531,7 +549,7 @@ intptr_t JASP_vmMain(intptr_t cmd, ...) {
 }
 
 
-void* JASP_GetGameAPI(void* import, void*) {
+static void* JASP_GetGameAPI(void* import, void*) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("JASP_GetGameAPI({}) called\n", import);
 
     // original import struct from engine
@@ -557,7 +575,7 @@ void* JASP_GetGameAPI(void* import, void*) {
 }
 
 
-bool JASP_mod_load(void* entry) {
+static bool JASP_mod_load(void* entry) {
     mod_GetGameAPI pfnGGA = (mod_GetGameAPI)entry;
     orig_export = (game_export_t*)pfnGGA(&qmm_import, nullptr);
 
@@ -565,12 +583,12 @@ bool JASP_mod_load(void* entry) {
 }
 
 
-void JASP_mod_unload() {
+static void JASP_mod_unload() {
     orig_export = nullptr;
 }
 
 
-const char* JASP_eng_msg_names(intptr_t cmd) {
+static const char* JASP_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_PRINTF);
         GEN_CASE(G_WRITECAM);
@@ -716,7 +734,7 @@ const char* JASP_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* JASP_mod_msg_names(intptr_t cmd) {
+static const char* JASP_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAMEV_APIVERSION);
         GEN_CASE(GAME_INIT);

--- a/src/game_jk2mp.cpp
+++ b/src/game_jk2mp.cpp
@@ -18,9 +18,28 @@ Created By:
 #include "game_jk2mp.h"
 #include "main.h"
 #include "mod.h"
+#include "util.h"
 
 GEN_QMM_MSGS(JK2MP);
 GEN_EXTS(JK2MP);
+
+GEN_DLLQVM(JK2MP);
+
+
+// auto-detection logic for JK2MP
+static bool JK2MP_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "jk2mp") && !str_stristr(g_gameinfo.exe_file, "jk2ded"))
+        return false;
+
+    return true;
+}
+
 
 // original syscall pointer that comes from the game engine
 static eng_syscall orig_syscall = nullptr;
@@ -30,7 +49,7 @@ static mod_vmMain orig_vmMain = nullptr;
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t JK2MP_syscall(intptr_t cmd, ...) {
+static intptr_t JK2MP_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -77,7 +96,7 @@ intptr_t JK2MP_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t JK2MP_vmMain(intptr_t cmd, ...) {
+static intptr_t JK2MP_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -107,7 +126,7 @@ intptr_t JK2MP_vmMain(intptr_t cmd, ...) {
 }
 
 
-void JK2MP_dllEntry(eng_syscall syscall) {
+static void JK2MP_dllEntry(eng_syscall syscall) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("JK2MP_dllEntry({}) called\n", (void*)syscall);
 
     // store original syscall from engine
@@ -123,19 +142,19 @@ void JK2MP_dllEntry(eng_syscall syscall) {
 }
 
 
-bool JK2MP_mod_load(void* entry) {
+static bool JK2MP_mod_load(void* entry) {
     orig_vmMain = (mod_vmMain)entry;
 
     return !!orig_vmMain;
 }
 
 
-void JK2MP_mod_unload() {
+static void JK2MP_mod_unload() {
     orig_vmMain = nullptr;
 }
 
 
-const char* JK2MP_eng_msg_names(intptr_t cmd) {
+static const char* JK2MP_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_PRINT);
         GEN_CASE(G_ERROR);
@@ -374,7 +393,7 @@ const char* JK2MP_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* JK2MP_mod_msg_names(intptr_t cmd) {
+static const char* JK2MP_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAME_INIT);
         GEN_CASE(GAME_SHUTDOWN);

--- a/src/game_jk2sp.cpp
+++ b/src/game_jk2sp.cpp
@@ -22,6 +22,24 @@ Created By:
 GEN_QMM_MSGS(JK2SP);
 GEN_EXTS(JK2SP);
 
+GEN_GGA(JK2SP);
+
+
+// auto-detection logic for JK2SP
+static bool JK2SP_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (!is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "jk2sp") && !str_stristr(g_gameinfo.exe_file, "openjo_sp"))
+        return false;
+
+    return true;
+}
+
+
 // a copy of the original import struct that comes from the game engine
 static game_import_t orig_import;
 
@@ -206,7 +224,7 @@ static void s_update_export() {
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t JK2SP_syscall(intptr_t cmd, ...) {
+static intptr_t JK2SP_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -402,7 +420,7 @@ intptr_t JK2SP_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t JK2SP_vmMain(intptr_t cmd, ...) {
+static intptr_t JK2SP_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -453,7 +471,7 @@ intptr_t JK2SP_vmMain(intptr_t cmd, ...) {
 }
 
 
-void* JK2SP_GetGameAPI(void* import, void*) {
+static void* JK2SP_GetGameAPI(void* import, void*) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("JK2SP_GetGameAPI({}) called\n", import);
 
     // original import struct from engine
@@ -479,7 +497,7 @@ void* JK2SP_GetGameAPI(void* import, void*) {
 }
 
 
-bool JK2SP_mod_load(void* entry) {
+static bool JK2SP_mod_load(void* entry) {
     mod_GetGameAPI pfnGGA = (mod_GetGameAPI)entry;
     orig_export = (game_export_t*)pfnGGA(&qmm_import, nullptr);
 
@@ -487,12 +505,12 @@ bool JK2SP_mod_load(void* entry) {
 }
 
 
-void JK2SP_mod_unload() {
+static void JK2SP_mod_unload() {
     orig_export = nullptr;
 }
 
 
-const char* JK2SP_eng_msg_names(intptr_t cmd) {
+static const char* JK2SP_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_PRINTF);
         GEN_CASE(G_WRITECAM);
@@ -610,7 +628,7 @@ const char* JK2SP_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* JK2SP_mod_msg_names(intptr_t cmd) {
+static const char* JK2SP_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAMEV_APIVERSION);
         GEN_CASE(GAME_INIT);

--- a/src/game_mohaa.cpp
+++ b/src/game_mohaa.cpp
@@ -27,6 +27,24 @@ Created By:
 GEN_QMM_MSGS(MOHAA);
 GEN_EXTS(MOHAA);
 
+GEN_GGA(MOHAA);
+
+
+// auto-detection logic for MOHAA
+static bool MOHAA_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (!is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "mohaa"))
+        return false;
+
+    return true;
+}
+
+
 // a copy of the original import struct that comes from the game engine
 static game_import_t orig_import;
 
@@ -309,7 +327,7 @@ static void s_update_export() {
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t MOHAA_syscall(intptr_t cmd, ...) {
+static intptr_t MOHAA_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -650,7 +668,7 @@ intptr_t MOHAA_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t MOHAA_vmMain(intptr_t cmd, ...) {
+static intptr_t MOHAA_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -723,7 +741,7 @@ intptr_t MOHAA_vmMain(intptr_t cmd, ...) {
 }
 
 
-void* MOHAA_GetGameAPI(void* import, void*) {
+static void* MOHAA_GetGameAPI(void* import, void*) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("MOHAA_GetGameAPI({}) called\n", import);
 
     // original import struct from engine
@@ -753,7 +771,7 @@ void* MOHAA_GetGameAPI(void* import, void*) {
 }
 
 
-bool MOHAA_mod_load(void* entry) {
+static bool MOHAA_mod_load(void* entry) {
     mod_GetGameAPI pfnGGA = (mod_GetGameAPI)entry;
     orig_export = (game_export_t*)pfnGGA(&qmm_import, nullptr);
 
@@ -761,12 +779,12 @@ bool MOHAA_mod_load(void* entry) {
 }
 
 
-void MOHAA_mod_unload() {
+static void MOHAA_mod_unload() {
     orig_export = nullptr;
 }
 
 
-const char* MOHAA_eng_msg_names(intptr_t cmd) {
+static const char* MOHAA_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_PRINTF);
         GEN_CASE(G_DPRINTF);
@@ -948,7 +966,7 @@ const char* MOHAA_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* MOHAA_mod_msg_names(intptr_t cmd) {
+static const char* MOHAA_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAMEV_APIVERSION);
         GEN_CASE(GAME_INIT);

--- a/src/game_mohbt.cpp
+++ b/src/game_mohbt.cpp
@@ -27,6 +27,24 @@ Created By:
 GEN_QMM_MSGS(MOHBT);
 GEN_EXTS(MOHBT);
 
+GEN_GGA(MOHBT);
+
+
+// auto-detection logic for MOHBT
+static bool MOHBT_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (!is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "break"))
+        return false;
+
+    return true;
+}
+
+
 // a copy of the original import struct that comes from the game engine
 static game_import_t orig_import;
 
@@ -317,7 +335,7 @@ static void s_update_export() {
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t MOHBT_syscall(intptr_t cmd, ...) {
+static intptr_t MOHBT_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -689,7 +707,7 @@ intptr_t MOHBT_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t MOHBT_vmMain(intptr_t cmd, ...) {
+static intptr_t MOHBT_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -762,7 +780,7 @@ intptr_t MOHBT_vmMain(intptr_t cmd, ...) {
 }
 
 
-void* MOHBT_GetGameAPI(void* import, void*) {
+static void* MOHBT_GetGameAPI(void* import, void*) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("MOHBT_GetGameAPI({}) called\n", import);
 
     // original import struct from engine
@@ -792,7 +810,7 @@ void* MOHBT_GetGameAPI(void* import, void*) {
 }
 
 
-bool MOHBT_mod_load(void* entry) {
+static bool MOHBT_mod_load(void* entry) {
     mod_GetGameAPI pfnGGA = (mod_GetGameAPI)entry;
     orig_export = (game_export_t*)pfnGGA(&qmm_import, nullptr);
 
@@ -800,12 +818,12 @@ bool MOHBT_mod_load(void* entry) {
 }
 
 
-void MOHBT_mod_unload() {
+static void MOHBT_mod_unload() {
     orig_export = nullptr;
 }
 
 
-const char* MOHBT_eng_msg_names(intptr_t cmd) {
+static const char* MOHBT_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_PRINTF);
         GEN_CASE(G_DPRINTF);
@@ -994,7 +1012,7 @@ const char* MOHBT_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* MOHBT_mod_msg_names(intptr_t cmd) {
+static const char* MOHBT_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAMEV_APIVERSION);
         GEN_CASE(GAME_INIT);

--- a/src/game_mohsh.cpp
+++ b/src/game_mohsh.cpp
@@ -27,6 +27,24 @@ Created By:
 GEN_QMM_MSGS(MOHSH);
 GEN_EXTS(MOHSH);
 
+GEN_GGA(MOHSH);
+
+
+// auto-detection logic for MOHSH
+static bool MOHSH_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (!is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "spear"))
+        return false;
+
+    return true;
+}
+
+
 // a copy of the original import struct that comes from the game engine
 static game_import_t orig_import;
 
@@ -317,7 +335,7 @@ static void s_update_export() {
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t MOHSH_syscall(intptr_t cmd, ...) {
+static intptr_t MOHSH_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -689,7 +707,7 @@ intptr_t MOHSH_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t MOHSH_vmMain(intptr_t cmd, ...) {
+static intptr_t MOHSH_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -762,7 +780,7 @@ intptr_t MOHSH_vmMain(intptr_t cmd, ...) {
 }
 
 
-void* MOHSH_GetGameAPI(void* import, void*) {
+static void* MOHSH_GetGameAPI(void* import, void*) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("MOHSH_GetGameAPI({}) called\n", import);
 
     // original import struct from engine
@@ -792,7 +810,7 @@ void* MOHSH_GetGameAPI(void* import, void*) {
 }
 
 
-bool MOHSH_mod_load(void* entry) {
+static bool MOHSH_mod_load(void* entry) {
     mod_GetGameAPI pfnGGA = (mod_GetGameAPI)entry;
     orig_export = (game_export_t*)pfnGGA(&qmm_import, nullptr);
 
@@ -800,12 +818,12 @@ bool MOHSH_mod_load(void* entry) {
 }
 
 
-void MOHSH_mod_unload() {
+static void MOHSH_mod_unload() {
     orig_export = nullptr;
 }
 
 
-const char* MOHSH_eng_msg_names(intptr_t cmd) {
+static const char* MOHSH_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_PRINTF);
         GEN_CASE(G_DPRINTF);
@@ -994,7 +1012,7 @@ const char* MOHSH_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* MOHSH_mod_msg_names(intptr_t cmd) {
+static const char* MOHSH_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAMEV_APIVERSION);
         GEN_CASE(GAME_INIT);

--- a/src/game_q2r.cpp
+++ b/src/game_q2r.cpp
@@ -35,6 +35,24 @@ GEN_QMM_MSGS(Q2R);
 #undef GAME_INIT
 GEN_EXTS(Q2R);
 
+GEN_GGA(Q2R);
+
+
+// auto-detection logic for Q2R
+static bool Q2R_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (!is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "quake2ex"))
+        return false;
+
+    return true;
+}
+
+
 // a copy of the original import struct that comes from the game engine
 static game_import_t orig_import;
 
@@ -258,7 +276,7 @@ static void s_update_export() {
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t Q2R_syscall(intptr_t cmd, ...) {
+static intptr_t Q2R_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -511,7 +529,7 @@ intptr_t Q2R_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t Q2R_vmMain(intptr_t cmd, ...) {
+static intptr_t Q2R_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -577,7 +595,7 @@ intptr_t Q2R_vmMain(intptr_t cmd, ...) {
 }
 
 
-void* Q2R_GetGameAPI(void* import, void*) {
+static void* Q2R_GetGameAPI(void* import, void*) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("Q2R_GetGameAPI({}) called\n", import);
 
     // original import struct from engine
@@ -605,7 +623,7 @@ void* Q2R_GetGameAPI(void* import, void*) {
 }
 
 
-bool Q2R_mod_load(void* entry) {
+static bool Q2R_mod_load(void* entry) {
     mod_GetGameAPI pfnGGA = (mod_GetGameAPI)entry;
     orig_export = (game_export_t*)pfnGGA(&qmm_import, nullptr);
 
@@ -613,12 +631,12 @@ bool Q2R_mod_load(void* entry) {
 }
 
 
-void Q2R_mod_unload() {
+static void Q2R_mod_unload() {
     orig_export = nullptr;
 }
 
 
-const char* Q2R_eng_msg_names(intptr_t cmd) {
+static const char* Q2R_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_BROADCAST_PRINT);
         GEN_CASE(G_COM_PRINT);
@@ -713,7 +731,7 @@ const char* Q2R_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* Q2R_mod_msg_names(intptr_t cmd) {
+static const char* Q2R_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAMEV_APIVERSION);
         GEN_CASE(GAME_PREINIT);

--- a/src/game_q3a.cpp
+++ b/src/game_q3a.cpp
@@ -18,9 +18,28 @@ Created By:
 #include "game_q3a.h"
 #include "main.h"
 #include "mod.h"
+#include "util.h"
 
 GEN_QMM_MSGS(Q3A);
 GEN_EXTS(Q3A);
+
+GEN_DLLQVM(Q3A);
+
+
+// auto-detection logic for Q3A
+static bool Q3A_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "quake3") && !str_stristr(g_gameinfo.exe_file, "q3ded"))
+        return false;
+
+    return true;
+}
+
 
 // original syscall pointer that comes from the game engine
 static eng_syscall orig_syscall = nullptr;
@@ -30,7 +49,7 @@ static mod_vmMain orig_vmMain = nullptr;
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t Q3A_syscall(intptr_t cmd, ...) {
+static intptr_t Q3A_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -76,7 +95,7 @@ intptr_t Q3A_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t Q3A_vmMain(intptr_t cmd, ...) {
+static intptr_t Q3A_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -106,7 +125,7 @@ intptr_t Q3A_vmMain(intptr_t cmd, ...) {
 }
 
 
-void Q3A_dllEntry(eng_syscall syscall) {
+static void Q3A_dllEntry(eng_syscall syscall) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("Q3A_dllEntry({}) called\n", (void*)syscall);
 
     // store original syscall from engine
@@ -122,19 +141,19 @@ void Q3A_dllEntry(eng_syscall syscall) {
 }
 
 
-bool Q3A_mod_load(void* entry) {
+static bool Q3A_mod_load(void* entry) {
     orig_vmMain = (mod_vmMain)entry;
 
     return !!orig_vmMain;
 }
 
 
-void Q3A_mod_unload() {
+static void Q3A_mod_unload() {
     orig_vmMain = nullptr;
 }
 
 
-const char* Q3A_eng_msg_names(intptr_t cmd) {
+static const char* Q3A_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_PRINT);
         GEN_CASE(G_ERROR);
@@ -343,7 +362,7 @@ const char* Q3A_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* Q3A_mod_msg_names(intptr_t cmd) {
+static const char* Q3A_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAME_INIT);
         GEN_CASE(GAME_SHUTDOWN);
@@ -369,7 +388,7 @@ const char* Q3A_mod_msg_names(intptr_t cmd) {
 */
 // vec3_t are arrays, so convert them as pointers
 // for double pointers (gentity_t** and vec3_t*), convert them once with vmptr()
-int Q3A_qvmsyscall(uint8_t* membase, int cmd, int* args) {
+static int Q3A_qvmsyscall(uint8_t* membase, int cmd, int* args) {
 #ifdef _DEBUG
     LOG(QMM_LOG_TRACE, "QMM") << fmt::format("Q3A_qvmsyscall({} {}) called\n", Q3A_eng_msg_names(cmd), cmd);
 #endif

--- a/src/game_quake2.cpp
+++ b/src/game_quake2.cpp
@@ -25,6 +25,24 @@ Created By:
 GEN_QMM_MSGS(QUAKE2);
 GEN_EXTS(QUAKE2);
 
+GEN_GGA(QUAKE2);
+
+
+// auto-detection logic for QUAKE2
+static bool QUAKE2_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (!is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "quake2") && !str_stristr(g_gameinfo.exe_file, "q2ded"))
+        return false;
+
+    return true;
+}
+
+
 // a copy of the original import struct that comes from the game engine
 static game_import_t orig_import;
 
@@ -201,7 +219,7 @@ static void s_update_export() {
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t QUAKE2_syscall(intptr_t cmd, ...) {
+static intptr_t QUAKE2_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -444,7 +462,7 @@ intptr_t QUAKE2_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t QUAKE2_vmMain(intptr_t cmd, ...) {
+static intptr_t QUAKE2_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -496,7 +514,7 @@ intptr_t QUAKE2_vmMain(intptr_t cmd, ...) {
 }
 
 
-void* QUAKE2_GetGameAPI(void* import, void*) {
+static void* QUAKE2_GetGameAPI(void* import, void*) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("QUAKE2_GetGameAPI({}) called\n", import);
 
     // original import struct from engine
@@ -522,7 +540,7 @@ void* QUAKE2_GetGameAPI(void* import, void*) {
 }
 
 
-bool QUAKE2_mod_load(void* entry) {
+static bool QUAKE2_mod_load(void* entry) {
     mod_GetGameAPI pfnGGA = (mod_GetGameAPI)entry;
     orig_export = (game_export_t*)pfnGGA(&qmm_import, nullptr);
 
@@ -530,12 +548,12 @@ bool QUAKE2_mod_load(void* entry) {
 }
 
 
-void QUAKE2_mod_unload() {
+static void QUAKE2_mod_unload() {
     orig_export = nullptr;
 }
 
 
-const char* QUAKE2_eng_msg_names(intptr_t cmd) {
+static const char* QUAKE2_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_BPRINTF);
         GEN_CASE(G_DPRINTF);
@@ -606,7 +624,7 @@ const char* QUAKE2_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* QUAKE2_mod_msg_names(intptr_t cmd) {
+static const char* QUAKE2_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAMEV_APIVERSION);
         GEN_CASE(GAME_INIT);

--- a/src/game_rtcwmp.cpp
+++ b/src/game_rtcwmp.cpp
@@ -17,10 +17,28 @@ Created By:
 // QMM-specific RTCWMP header
 #include "game_q3a.h"
 #include "main.h"
-#include "mod.h"
+#include "util.h"
 
 GEN_QMM_MSGS(RTCWMP);
 GEN_EXTS(RTCWMP);
+
+GEN_DLL(RTCWMP);
+
+
+// auto-detection logic for RTCWMP
+static bool RTCWMP_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "wolfmp") && !str_stristr(g_gameinfo.exe_file, "wolfded"))
+        return false;
+
+    return true;
+}
+
 
 // original syscall pointer that comes from the game engine
 static eng_syscall orig_syscall = nullptr;
@@ -30,7 +48,7 @@ static mod_vmMain orig_vmMain = nullptr;
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t RTCWMP_syscall(intptr_t cmd, ...) {
+static intptr_t RTCWMP_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -77,7 +95,7 @@ intptr_t RTCWMP_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t RTCWMP_vmMain(intptr_t cmd, ...) {
+static intptr_t RTCWMP_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -101,7 +119,7 @@ intptr_t RTCWMP_vmMain(intptr_t cmd, ...) {
 }
 
 
-void RTCWMP_dllEntry(eng_syscall syscall) {
+static void RTCWMP_dllEntry(eng_syscall syscall) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("RTCWMP_dllEntry({}) called\n", (void*)syscall);
 
     // store original syscall from engine
@@ -117,19 +135,19 @@ void RTCWMP_dllEntry(eng_syscall syscall) {
 }
 
 
-bool RTCWMP_mod_load(void* entry) {
+static bool RTCWMP_mod_load(void* entry) {
     orig_vmMain = (mod_vmMain)entry;
 
     return !!orig_vmMain;
 }
 
 
-void RTCWMP_mod_unload() {
+static void RTCWMP_mod_unload() {
     orig_vmMain = nullptr;
 }
 
 
-const char* RTCWMP_eng_msg_names(intptr_t cmd) {
+static const char* RTCWMP_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_PRINT);
         GEN_CASE(G_ERROR);
@@ -335,7 +353,7 @@ const char* RTCWMP_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* RTCWMP_mod_msg_names(intptr_t cmd) {
+static const char* RTCWMP_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAME_INIT);
         GEN_CASE(GAME_SHUTDOWN);

--- a/src/game_rtcwsp.cpp
+++ b/src/game_rtcwsp.cpp
@@ -17,10 +17,28 @@ Created By:
 // QMM-specific RTCWSP header
 #include "game_q3a.h"
 #include "main.h"
-#include "mod.h"
+#include "util.h"
 
 GEN_QMM_MSGS(RTCWSP);
 GEN_EXTS(RTCWSP);
+
+GEN_DLL(RTCWSP);
+
+
+// auto-detection logic for RTCWSP
+static bool RTCWSP_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "wolfsp"))
+        return false;
+
+    return true;
+}
+
 
 // original syscall pointer that comes from the game engine
 static eng_syscall orig_syscall = nullptr;
@@ -30,7 +48,7 @@ static mod_vmMain orig_vmMain = nullptr;
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t RTCWSP_syscall(intptr_t cmd, ...) {
+static intptr_t RTCWSP_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -77,7 +95,7 @@ intptr_t RTCWSP_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t RTCWSP_vmMain(intptr_t cmd, ...) {
+static intptr_t RTCWSP_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -101,7 +119,7 @@ intptr_t RTCWSP_vmMain(intptr_t cmd, ...) {
 }
 
 
-void RTCWSP_dllEntry(eng_syscall syscall) {
+static void RTCWSP_dllEntry(eng_syscall syscall) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("RTCWSP_dllEntry({}) called\n", (void*)syscall);
 
     // store original syscall from engine
@@ -117,19 +135,19 @@ void RTCWSP_dllEntry(eng_syscall syscall) {
 }
 
 
-bool RTCWSP_mod_load(void* entry) {
+static bool RTCWSP_mod_load(void* entry) {
     orig_vmMain = (mod_vmMain)entry;
 
     return !!orig_vmMain;
 }
 
 
-void RTCWSP_mod_unload() {
+static void RTCWSP_mod_unload() {
     orig_vmMain = nullptr;
 }
 
 
-const char* RTCWSP_eng_msg_names(intptr_t cmd) {
+static const char* RTCWSP_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_PRINT);
         GEN_CASE(G_ERROR);
@@ -338,7 +356,7 @@ const char* RTCWSP_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* RTCWSP_mod_msg_names(intptr_t cmd) {
+static const char* RTCWSP_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAME_INIT);
         GEN_CASE(GAME_SHUTDOWN);

--- a/src/game_sin.cpp
+++ b/src/game_sin.cpp
@@ -25,6 +25,24 @@ Created By:
 GEN_QMM_MSGS(SIN);
 GEN_EXTS(SIN);
 
+GEN_GGA(SIN);
+
+
+// auto-detection logic for SIN
+static bool SIN_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (!is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "sin"))
+        return false;
+
+    return true;
+}
+
+
 // a copy of the original import struct that comes from the game engine
 static game_import_t orig_import;
 
@@ -268,7 +286,7 @@ static void s_update_export() {
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t SIN_syscall(intptr_t cmd, ...) {
+static intptr_t SIN_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -550,7 +568,7 @@ intptr_t SIN_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t SIN_vmMain(intptr_t cmd, ...) {
+static intptr_t SIN_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -612,7 +630,7 @@ intptr_t SIN_vmMain(intptr_t cmd, ...) {
 }
 
 
-void* SIN_GetGameAPI(void* import, void*) {
+static void* SIN_GetGameAPI(void* import, void*) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("SIN_GetGameAPI({}) called\n", import);
 
     // original import struct from engine
@@ -639,7 +657,7 @@ void* SIN_GetGameAPI(void* import, void*) {
 }
 
 
-bool SIN_mod_load(void* entry) {
+static bool SIN_mod_load(void* entry) {
     mod_GetGameAPI pfnGGA = (mod_GetGameAPI)entry;
     orig_export = (game_export_t*)pfnGGA(&qmm_import, nullptr);
 
@@ -647,12 +665,12 @@ bool SIN_mod_load(void* entry) {
 }
 
 
-void SIN_mod_unload() {
+static void SIN_mod_unload() {
     orig_export = nullptr;
 }
 
 
-const char* SIN_eng_msg_names(intptr_t cmd) {
+static const char* SIN_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_BPRINTF);
         GEN_CASE(G_DPRINTF);
@@ -768,7 +786,7 @@ const char* SIN_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* SIN_mod_msg_names(intptr_t cmd) {
+static const char* SIN_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAMEV_APIVERSION);
         GEN_CASE(GAME_INIT);

--- a/src/game_sof2mp.cpp
+++ b/src/game_sof2mp.cpp
@@ -19,9 +19,28 @@ Created By:
 #include "game_sof2mp.h"
 #include "main.h"
 #include "mod.h"
+#include "util.h"
 
 GEN_QMM_MSGS(SOF2MP);
 GEN_EXTS(SOF2MP);
+
+GEN_DLLQVM(SOF2MP);
+
+
+// auto-detection logic for SOF2MP
+static bool SOF2MP_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "sof2mp") && !str_stristr(g_gameinfo.exe_file, "sof2ded"))
+        return false;
+
+    return true;
+}
+
 
 // original syscall pointer that comes from the game engine
 static eng_syscall orig_syscall = nullptr;
@@ -31,7 +50,7 @@ static mod_vmMain orig_vmMain = nullptr;
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t SOF2MP_syscall(intptr_t cmd, ...) {
+static intptr_t SOF2MP_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -79,7 +98,7 @@ intptr_t SOF2MP_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t SOF2MP_vmMain(intptr_t cmd, ...) {
+static intptr_t SOF2MP_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -143,7 +162,7 @@ intptr_t SOF2MP_vmMain(intptr_t cmd, ...) {
 }
 
 
-void SOF2MP_dllEntry(eng_syscall syscall) {
+static void SOF2MP_dllEntry(eng_syscall syscall) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("SOF2MP_dllEntry({}) called\n", (void*)syscall);
 
     // store original syscall from engine
@@ -160,7 +179,7 @@ void SOF2MP_dllEntry(eng_syscall syscall) {
 
 
 // get mod's vmMain function pointer from mod.cpp::mod_load
-bool SOF2MP_mod_load(void* entry) {
+static bool SOF2MP_mod_load(void* entry) {
     orig_vmMain = (mod_vmMain)entry;
 
     // we cannot verify data in the QVM since this engine both provides malloc functionality and has the gametype module,
@@ -172,12 +191,12 @@ bool SOF2MP_mod_load(void* entry) {
 }
 
 
-void SOF2MP_mod_unload() {
+static void SOF2MP_mod_unload() {
     orig_vmMain = nullptr;
 }
 
 
-const char* SOF2MP_eng_msg_names(intptr_t cmd) {
+static const char* SOF2MP_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_PRINT);
         GEN_CASE(G_ERROR);
@@ -450,7 +469,7 @@ const char* SOF2MP_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* SOF2MP_mod_msg_names(intptr_t cmd) {
+static const char* SOF2MP_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAME_INIT);
         GEN_CASE(GAME_SHUTDOWN);
@@ -482,7 +501,7 @@ const char* SOF2MP_mod_msg_names(intptr_t cmd) {
 // do NOT convert the "ghoul" void pointers, treat them as plain ints
 // TGPValue, TGPGroup, and TGenericParser2 are void*, but treat them as plain ints
 // for double pointers (gentity_t**, vec3_t*, void**), convert them once with vmptr()
-int SOF2MP_qvmsyscall(uint8_t* membase, int cmd, int* args) {
+static int SOF2MP_qvmsyscall(uint8_t* membase, int cmd, int* args) {
 #ifdef _DEBUG
     LOG(QMM_LOG_TRACE, "QMM") << fmt::format("SOF2MP_qvmsyscall({} {}) called\n", SOF2MP_eng_msg_names(cmd), cmd);
 #endif

--- a/src/game_sof2sp.cpp
+++ b/src/game_sof2sp.cpp
@@ -21,6 +21,24 @@ Created By:
 GEN_QMM_MSGS(SOF2SP);
 GEN_EXTS(SOF2SP);
 
+GEN_GGA(SOF2SP);
+
+
+// auto-detection logic for SOF2SP
+static bool SOF2SP_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (!is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "sof2"))
+        return false;
+
+    return true;
+}
+
+
 // a copy of the apiversion int that comes from the game engine
 static intptr_t orig_apiversion = 0;
 
@@ -191,7 +209,7 @@ static void s_update_export() {
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t SOF2SP_syscall(intptr_t cmd, ...) {
+static intptr_t SOF2SP_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -367,7 +385,7 @@ intptr_t SOF2SP_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t SOF2SP_vmMain(intptr_t cmd, ...) {
+static intptr_t SOF2SP_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -424,7 +442,7 @@ intptr_t SOF2SP_vmMain(intptr_t cmd, ...) {
 }
 
 
-void* SOF2SP_GetGameAPI(void* apiversion, void* import) {
+static void* SOF2SP_GetGameAPI(void* apiversion, void* import) {
     orig_apiversion = (intptr_t)apiversion;
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("SOF2SP_GetGameAPI({}, {}) called\n", orig_apiversion, import);
 
@@ -451,7 +469,7 @@ void* SOF2SP_GetGameAPI(void* apiversion, void* import) {
 }
 
 
-bool SOF2SP_mod_load(void* entry) {
+static bool SOF2SP_mod_load(void* entry) {
     mod_GetGameAPI pfnGGA = (mod_GetGameAPI)entry;
     // api version gets passed before import pointer
     orig_export = (game_export_t*)pfnGGA((void*)orig_apiversion, &qmm_import);
@@ -460,12 +478,12 @@ bool SOF2SP_mod_load(void* entry) {
 }
 
 
-void SOF2SP_mod_unload() {
+static void SOF2SP_mod_unload() {
     orig_export = nullptr;
 }
 
 
-const char* SOF2SP_eng_msg_names(intptr_t cmd) {
+static const char* SOF2SP_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_PRINTF);
         GEN_CASE(G_DPRINTF);
@@ -590,7 +608,7 @@ const char* SOF2SP_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* SOF2SP_mod_msg_names(intptr_t cmd) {
+static const char* SOF2SP_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAME_INIT);
         GEN_CASE(GAME_SHUTDOWN);

--- a/src/game_stef2.cpp
+++ b/src/game_stef2.cpp
@@ -24,6 +24,24 @@ Created By:
 GEN_QMM_MSGS(STEF2);
 GEN_EXTS(STEF2);
 
+GEN_GGA(STEF2);
+
+
+// auto-detection logic for STEF2
+static bool STEF2_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (!is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "ef"))
+        return false;
+
+    return true;
+}
+
+
 // a copy of the original import struct that comes from the game engine
 static game_import_t orig_import;
 
@@ -466,7 +484,7 @@ static void s_update_export() {
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t STEF2_syscall(intptr_t cmd, ...) {
+static intptr_t STEF2_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -871,7 +889,7 @@ intptr_t STEF2_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t STEF2_vmMain(intptr_t cmd, ...) {
+static intptr_t STEF2_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -940,7 +958,7 @@ intptr_t STEF2_vmMain(intptr_t cmd, ...) {
 }
 
 
-void* STEF2_GetGameAPI(void* import, void*) {
+static void* STEF2_GetGameAPI(void* import, void*) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("STEF2_GetGameAPI({}) called\n", import);
 
     // original import struct from engine
@@ -967,7 +985,7 @@ void* STEF2_GetGameAPI(void* import, void*) {
 }
 
 
-bool STEF2_mod_load(void* entry) {
+static bool STEF2_mod_load(void* entry) {
     mod_GetGameAPI pfnGGA = (mod_GetGameAPI)entry;
     orig_export = (game_export_t*)pfnGGA(&qmm_import, nullptr);
 
@@ -975,12 +993,12 @@ bool STEF2_mod_load(void* entry) {
 }
 
 
-void STEF2_mod_unload() {
+static void STEF2_mod_unload() {
     orig_export = nullptr;
 }
 
 
-const char* STEF2_eng_msg_names(intptr_t cmd) {
+static const char* STEF2_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_PRINTF);
         GEN_CASE(G_DPRINTF);
@@ -1333,7 +1351,7 @@ const char* STEF2_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* STEF2_mod_msg_names(intptr_t cmd) {
+static const char* STEF2_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAMEV_APIVERSION);
         GEN_CASE(GAME_INIT);

--- a/src/game_stvoyhm.cpp
+++ b/src/game_stvoyhm.cpp
@@ -18,9 +18,28 @@ Created By:
 #include "game_q3a.h"
 #include "main.h"
 #include "mod.h"
+#include "util.h"
 
 GEN_QMM_MSGS(STVOYHM);
 GEN_EXTS(STVOYHM);
+
+GEN_DLLQVM(STVOYHM);
+
+
+// auto-detection logic for Q3A
+static bool STVOYHM_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "stvoyhm"))
+        return false;
+
+    return true;
+}
+
 
 // original syscall pointer that comes from the game engine
 static eng_syscall orig_syscall = nullptr;
@@ -30,7 +49,7 @@ static mod_vmMain orig_vmMain = nullptr;
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t STVOYHM_syscall(intptr_t cmd, ...) {
+static intptr_t STVOYHM_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -77,7 +96,7 @@ intptr_t STVOYHM_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t STVOYHM_vmMain(intptr_t cmd, ...) {
+static intptr_t STVOYHM_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -107,7 +126,7 @@ intptr_t STVOYHM_vmMain(intptr_t cmd, ...) {
 }
 
 
-void STVOYHM_dllEntry(eng_syscall syscall) {
+static void STVOYHM_dllEntry(eng_syscall syscall) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("STVOYHM_dllEntry({}) called\n", (void*)syscall);
 
     // store original syscall from engine
@@ -123,19 +142,19 @@ void STVOYHM_dllEntry(eng_syscall syscall) {
 }
 
 
-bool STVOYHM_mod_load(void* entry) {
+static bool STVOYHM_mod_load(void* entry) {
     orig_vmMain = (mod_vmMain)entry;
 
     return !!orig_vmMain;
 }
 
 
-void STVOYHM_mod_unload() {
+static void STVOYHM_mod_unload() {
     orig_vmMain = nullptr;
 }
 
 
-const char* STVOYHM_eng_msg_names(intptr_t cmd) {
+static const char* STVOYHM_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_PRINT);
         GEN_CASE(G_ERROR);
@@ -335,7 +354,7 @@ const char* STVOYHM_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* STVOYHM_mod_msg_names(intptr_t cmd) {
+static const char* STVOYHM_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAME_INIT);
         GEN_CASE(GAME_SHUTDOWN);
@@ -361,7 +380,7 @@ const char* STVOYHM_mod_msg_names(intptr_t cmd) {
 */
 // vec3_t are arrays, so convert them as pointers
 // for double pointers (gentity_t** and vec3_t*), convert them once with vmptr()
-int STVOYHM_qvmsyscall(uint8_t* membase, int cmd, int* args) {
+static int STVOYHM_qvmsyscall(uint8_t* membase, int cmd, int* args) {
 #ifdef _DEBUG
     LOG(QMM_LOG_TRACE, "QMM") << fmt::format("STVOYHM_qvmsyscall({} {}) called\n", STVOYHM_eng_msg_names(cmd), cmd);
 #endif

--- a/src/game_stvoysp.cpp
+++ b/src/game_stvoysp.cpp
@@ -22,6 +22,24 @@ Created By:
 GEN_QMM_MSGS(STVOYSP);
 GEN_EXTS(STVOYSP);
 
+GEN_GGA(STVOYSP);
+
+
+// auto-detection logic for STVOYSP
+static bool STVOYSP_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (!is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "stvoy"))
+        return false;
+
+    return true;
+}
+
+
 // a copy of the original import struct that comes from the game engine
 static game_import_t orig_import;
 
@@ -144,7 +162,7 @@ static void s_update_export() {
 
 // wrapper syscall function that calls actual engine func from orig_import
 // this is how QMM and plugins will call into the engine
-intptr_t STVOYSP_syscall(intptr_t cmd, ...) {
+static intptr_t STVOYSP_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
@@ -279,7 +297,7 @@ intptr_t STVOYSP_syscall(intptr_t cmd, ...) {
 
 // wrapper vmMain function that calls actual mod func from orig_export
 // this is how QMM and plugins will call into the mod
-intptr_t STVOYSP_vmMain(intptr_t cmd, ...) {
+static intptr_t STVOYSP_vmMain(intptr_t cmd, ...) {
     QMM_GET_VMMAIN_ARGS();
 
 #ifdef _DEBUG
@@ -328,7 +346,7 @@ intptr_t STVOYSP_vmMain(intptr_t cmd, ...) {
 }
 
 
-void* STVOYSP_GetGameAPI(void* import, void*) {
+static void* STVOYSP_GetGameAPI(void* import, void*) {
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("STVOYSP_GetGameAPI({}) called\n", import);
 
     // original import struct from engine
@@ -354,7 +372,7 @@ void* STVOYSP_GetGameAPI(void* import, void*) {
 }
 
 
-bool STVOYSP_mod_load(void* entry) {
+static bool STVOYSP_mod_load(void* entry) {
     mod_GetGameAPI pfnGGA = (mod_GetGameAPI)entry;
     orig_export = (game_export_t*)pfnGGA(&qmm_import, nullptr);
 
@@ -362,12 +380,12 @@ bool STVOYSP_mod_load(void* entry) {
 }
 
 
-void STVOYSP_mod_unload() {
+static void STVOYSP_mod_unload() {
     orig_export = nullptr;
 }
 
 
-const char* STVOYSP_eng_msg_names(intptr_t cmd) {
+static const char* STVOYSP_eng_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(G_PRINTF);
         GEN_CASE(G_WRITECAM);
@@ -424,7 +442,7 @@ const char* STVOYSP_eng_msg_names(intptr_t cmd) {
 }
 
 
-const char* STVOYSP_mod_msg_names(intptr_t cmd) {
+static const char* STVOYSP_mod_msg_names(intptr_t cmd) {
     switch (cmd) {
         GEN_CASE(GAMEV_APIVERSION);
         GEN_CASE(GAME_INIT);

--- a/src/game_wet.cpp
+++ b/src/game_wet.cpp
@@ -17,10 +17,28 @@ Created By:
 // QMM-specific WET header
 #include "game_wet.h"
 #include "main.h"
-#include "mod.h"
+#include "util.h"
 
 GEN_QMM_MSGS(WET);
 GEN_EXTS(WET);
+
+GEN_DLL(WET);
+
+
+// auto-detection logic for WET
+static bool WET_autodetect(bool is_GetGameAPI, supportedgame* game) {
+    if (is_GetGameAPI)
+        return false;
+
+    if (!str_striequal(g_gameinfo.qmm_file, game->dllname))
+        return false;
+
+    if (!str_stristr(g_gameinfo.exe_file, "et"))
+        return false;
+
+    return true;
+}
+
 
 // original syscall pointer that comes from the game engine
 static eng_syscall orig_syscall = nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -246,13 +246,13 @@ C_DLLEXPORT intptr_t vmMain(intptr_t cmd, ...) {
         if (!g_gameinfo.is_shutdown) {
             g_gameinfo.is_shutdown = true;
             // if the syscall passed to dllEntry was null, this will crash, but this shouldn't happen
-            ENG_SYSCALL(QMM_FAIL_G_ERROR, "\n\n=========\nFatal QMM Error:\nQMM was unable to determine the game engine.\nPlease set the \"game\" option in qmm2.json.\nRefer to the documentation for more information.\n=========\n");
+            ENG_SYSCALL(QMM_FAIL_G_ERROR, "\nFatal QMM Error:\nQMM was unable to determine the game engine.\nPlease set the \"game\" option in qmm2.json.\nRefer to the documentation for more information.\n");
         }
         return 0;
     }
 
 #ifdef _DEBUG
-    LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("vmMain({} {}) called\n", g_gameinfo.game->mod_msg_names(cmd), cmd);
+    LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("vmMain({} {}) called\n", g_gameinfo.game->funcs->pfnModMsgNames(cmd), cmd);
 #endif
 
     if (cmd == msg_GAME_INIT) {
@@ -291,8 +291,8 @@ C_DLLEXPORT intptr_t vmMain(intptr_t cmd, ...) {
         cfg_mod = util_get_cmdline_arg("--qmm_mod", cfg_mod);
         if (!main_load_mod(cfg_mod)) {
             g_gameinfo.is_shutdown = true;
-            LOG(QMM_LOG_FATAL, "QMM") << fmt::format("vmMain({}): Unable to load mod using \"{}\"\n", g_gameinfo.game->mod_msg_names(cmd), cfg_mod);
-            ENG_SYSCALL(QMM_FAIL_G_ERROR, "\n\n=========\nFatal QMM Error:\nQMM was unable to load the mod file.\nPlease set the \"mod\" option in qmm2.json.\nRefer to the documentation for more information.\n=========\n");
+            LOG(QMM_LOG_FATAL, "QMM") << fmt::format("vmMain({}): Unable to load mod using \"{}\"\n", g_gameinfo.game->funcs->pfnModMsgNames(cmd), cfg_mod);
+            ENG_SYSCALL(QMM_FAIL_G_ERROR, "\nFatal QMM Error:\nQMM was unable to load the mod file.\nPlease set the \"mod\" option in qmm2.json.\nRefer to the documentation for more information.\n");
             return 0;
         }
         LOG(QMM_LOG_NOTICE, "QMM") << fmt::format("Successfully loaded {} mod \"{}\"\n", g_mod.vmbase ? "VM" : "DLL", g_mod.path);
@@ -383,7 +383,7 @@ C_DLLEXPORT intptr_t vmMain(intptr_t cmd, ...) {
     }
 
 #ifdef _DEBUG
-    LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("vmMain({} {}) returning {}\n", g_gameinfo.game->mod_msg_names(cmd), cmd, ret);
+    LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("vmMain({} {}) returning {}\n", g_gameinfo.game->funcs->pfnModMsgNames(cmd), cmd, ret);
 #endif
 
     return ret;
@@ -399,14 +399,14 @@ intptr_t qmm_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
 
 #ifdef _DEBUG
-    LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("syscall({} {}) called\n", g_gameinfo.game->eng_msg_names(cmd), cmd);
+    LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("syscall({} {}) called\n", g_gameinfo.game->funcs->pfnEngMsgNames(cmd), cmd);
 #endif
 
     // route call to plugins and mod
     intptr_t ret = main_route(true, cmd, args); // true = is_syscall
 
 #ifdef _DEBUG
-    LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("syscall({} {}) returning {}\n", g_gameinfo.game->eng_msg_names(cmd), cmd, ret);
+    LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("syscall({} {}) returning {}\n", g_gameinfo.game->funcs->pfnEngMsgNames(cmd), cmd, ret);
 #endif
 
     return ret;
@@ -465,20 +465,20 @@ static void* main_handle_entry(void* import, void* extra, bool is_GetGameAPI) {
     if (is_GetGameAPI) {
         // supported games table is missing game-specific GetGameAPI handler?
         // return nullptr to error out now. Init() will never be called
-        if (!g_gameinfo.game->pfnGetGameAPI) {
+        if (!g_gameinfo.game->funcs->pfnGetGameAPI) {
             LOG(QMM_LOG_FATAL, "QMM") << fmt::format("GetGameAPI(): pfnGetGameAPI handler for game \"{}\" is NULL!\n", g_gameinfo.game->gamename_short);
             return nullptr;
         }
 
         // call the game-specific GetGameAPI function (e.g. MOHAA_GetGameAPI) which will set up the exports for
         // returning here back to the game engine, as well as save the imports in preparation of loading the mod
-        return g_gameinfo.game->pfnGetGameAPI(import, extra);
+        return g_gameinfo.game->funcs->pfnGetGameAPI(import, extra);
     }
 
     // call the game-specific dllEntry function (e.g. Q3A_dllEntry) which will set up the functions to handle
     // vmMain and syscalls from the mod, engine, and plugins
-    if (g_gameinfo.game->pfndllEntry)
-        g_gameinfo.game->pfndllEntry((eng_syscall)import);
+    if (g_gameinfo.game->funcs->pfndllEntry)
+        g_gameinfo.game->funcs->pfndllEntry((eng_syscall)import);
     // supported games table is missing game-specific dllEntry handler? we can try to fake it by storing the
     // syscall pointer in g_gameinfo.pfnsyscall. also as a hack, s_mod_load_vmmain & s_mod_load_qvm will store
     // vmMain in g_gameinfo.pfnvmMain if it wasn't set already by the game-specific dllEntry
@@ -545,12 +545,8 @@ static void main_load_config(std::string config_filename) {
 
 // general code to auto-detect what game engine loaded us
 static void main_detect_game(std::string cfg_game, bool is_GetGameAPI) {
-    // find what game we are loaded in
     for (int i = 0; g_supportedgames[i].dllname; i++) {
         supportedgame& game = g_supportedgames[i];
-        // only check games with apientry based on GetGameAPI_mode
-        if (is_GetGameAPI != !!game.pfnGetGameAPI)
-            continue;
 
         // if short name matches config option, we found it!
         if (str_striequal(cfg_game, game.gamename_short)) {
@@ -559,25 +555,13 @@ static void main_detect_game(std::string cfg_game, bool is_GetGameAPI) {
             g_gameinfo.is_auto_detected = false;
             return;
         }
-        // otherwise, if auto, we need to check matching dll names, with optional exe hint
-        if (str_striequal(cfg_game, "auto") && str_striequal(g_gameinfo.qmm_file, game.dllname)) {
-            LOG(QMM_LOG_INFO, "QMM") << fmt::format("Found game match for dll name \"{}\" - {}\n", game.dllname, game.gamename_short);
-            // if no hint array exists, assume we match
-            if (!game.exe_hints.size()) {
-                LOG(QMM_LOG_NOTICE, "QMM") << fmt::format("No exe hint for game, assuming match\n");
-                g_gameinfo.game = &game;
-                g_gameinfo.is_auto_detected = true;
-                return;
-            }
-            // if a hint array exists, check each for an exe file match
-            for (std::string& hint : game.exe_hints) {
-                if (str_stristr(g_gameinfo.exe_file, hint)) {
-                    LOG(QMM_LOG_NOTICE, "QMM") << fmt::format("Found game match for exe hint \"{}\" - {}\n", hint, game.gamename_short);
-                    g_gameinfo.game = &game;
-                    g_gameinfo.is_auto_detected = true;
-                    return;
-                }
-            }
+
+        // otherwise, if auto, call the game's auto-detect function if available
+        if (str_striequal(cfg_game, "auto") && game.funcs->pfnAutoDetect && game.funcs->pfnAutoDetect(is_GetGameAPI, &game)) {
+            LOG(QMM_LOG_INFO, "QMM") << fmt::format("Found game match with auto-detection - \"{}\"\n", game.gamename_short);
+            g_gameinfo.game = &game;
+            g_gameinfo.is_auto_detected = true;
+            return;
         }
     }
 }
@@ -758,11 +742,11 @@ static intptr_t main_route(bool is_syscall, intptr_t cmd, intptr_t* args) {
     const char* func_name = nullptr;
 
     if (is_syscall) {
-        msg_names = g_gameinfo.game->eng_msg_names;
+        msg_names = g_gameinfo.game->funcs->pfnEngMsgNames;
         func_name = "syscall";
     }
     else {
-        msg_names = g_gameinfo.game->mod_msg_names;
+        msg_names = g_gameinfo.game->funcs->pfnModMsgNames;
         func_name = "vmMain";
     }
 

--- a/src/mod.cpp
+++ b/src/mod.cpp
@@ -42,7 +42,7 @@ bool mod_load(mod& mod, std::string file) {
     std::string ext = path_baseext(file);
 
     // only allow qvm mods if the game engine supports it
-    if (str_striequal(ext, EXT_QVM) && g_gameinfo.game->pfnqvmsyscall)
+    if (str_striequal(ext, EXT_QVM) && g_gameinfo.game->funcs->pfnqvmsyscall)
         return s_mod_load_qvm(mod);
 
     // if DLL
@@ -61,7 +61,7 @@ bool mod_load(mod& mod, std::string file) {
         }
 
         // pass off to engine-specific loading function
-        if (g_gameinfo.game->pfnGetGameAPI)
+        if (g_gameinfo.game->funcs->pfnGetGameAPI)
             return s_mod_load_getgameapi(mod);
         else
             return s_mod_load_vmmain(mod);
@@ -74,8 +74,8 @@ bool mod_load(mod& mod, std::string file) {
 
 void mod_unload(mod& mod) {
     // call the game-specific mod unload callback
-    if (g_gameinfo.game->pfnModUnload)
-        g_gameinfo.game->pfnModUnload();
+    if (g_gameinfo.game->funcs->pfnModUnload)
+        g_gameinfo.game->funcs->pfnModUnload();
     qvm_unload(&mod.vm);
     if (mod.dll)
         dlclose(mod.dll);
@@ -89,8 +89,8 @@ static intptr_t s_mod_qvm_vmmain(intptr_t cmd, ...) {
     if (!g_mod.vm.memory) {
         if (!g_gameinfo.is_shutdown) {
             g_gameinfo.is_shutdown = true;
-            LOG(QMM_LOG_FATAL, "QMM") << fmt::format("s_mod_vmmain({}): QVM unloaded during previous execution due to a run-time error\n", g_gameinfo.game->mod_msg_names(cmd));
-            ENG_SYSCALL(QMM_ENG_MSG[QMM_G_ERROR], "\n\n=========\nFatal QMM Error:\nThe QVM was unloaded during previous execution due to a run-time error.\n=========\n");
+            LOG(QMM_LOG_FATAL, "QMM") << fmt::format("s_mod_vmmain({}): QVM unloaded during previous execution due to a run-time error\n", g_gameinfo.game->funcs->pfnModMsgNames(cmd));
+            ENG_SYSCALL(QMM_ENG_MSG[QMM_G_ERROR], "\nFatal QMM Error:\nThe QVM was unloaded during previous execution due to a run-time error.\n");
         }
         return 0;
     }
@@ -111,11 +111,11 @@ static intptr_t s_mod_qvm_vmmain(intptr_t cmd, ...) {
 // handle syscalls from the QVM. passed to qvm_load
 static int s_mod_qvm_syscall(uint8_t* membase, int cmd, int* args) {
     // if no game-specific qvm handler, we need to error
-    if (!g_gameinfo.game->pfnqvmsyscall) {
+    if (!g_gameinfo.game->funcs->pfnqvmsyscall) {
         if (!g_gameinfo.is_shutdown) {
             g_gameinfo.is_shutdown = true;
-            LOG(QMM_LOG_FATAL, "QMM") << fmt::format("s_mod_qvm_syscall({}): No QVM syscall handler found\n", g_gameinfo.game->eng_msg_names(cmd));
-            ENG_SYSCALL(QMM_ENG_MSG[QMM_G_ERROR], "\n\n=========\nFatal QMM Error:\nNo QVM syscall handler found.\n=========\n");
+            LOG(QMM_LOG_FATAL, "QMM") << fmt::format("s_mod_qvm_syscall({}): No QVM syscall handler found\n", g_gameinfo.game->funcs->pfnEngMsgNames(cmd));
+            ENG_SYSCALL(QMM_ENG_MSG[QMM_G_ERROR], "\nFatal QMM Error:\nNo QVM syscall handler found.\n");
         }
         return 0;
     }
@@ -133,7 +133,7 @@ static int s_mod_qvm_syscall(uint8_t* membase, int cmd, int* args) {
     }
 
     // call the game-specific QVM syscall handler
-    return g_gameinfo.game->pfnqvmsyscall(membase, cmd, args);
+    return g_gameinfo.game->funcs->pfnqvmsyscall(membase, cmd, args);
 }
 
 
@@ -171,7 +171,7 @@ static bool s_mod_load_qvm(mod& mod) {
     mod.vmbase = (intptr_t)mod.vm.datasegment;
 
     // pass the qvm vmMain function pointer to the game-specific mod load handler
-    if (g_gameinfo.game->pfnModLoad && !g_gameinfo.game->pfnModLoad((void*)s_mod_qvm_vmmain)) {
+    if (g_gameinfo.game->funcs->pfnModLoad && !g_gameinfo.game->funcs->pfnModLoad((void*)s_mod_qvm_vmmain)) {
         LOG(QMM_LOG_ERROR, "QMM") << fmt::format("mod_load(\"{}\"): Mod load failed?\n", mod.path);
         goto fail;
     }
@@ -202,7 +202,7 @@ static bool s_mod_load_getgameapi(mod& mod) {
     mod.vmbase = 0;
 
     // pass the GetGameAPI function pointer to the game-specific mod load handler
-    if (!g_gameinfo.game->pfnModLoad || !g_gameinfo.game->pfnModLoad((void*)pfnGGA)) {
+    if (!g_gameinfo.game->funcs->pfnModLoad || !g_gameinfo.game->funcs->pfnModLoad((void*)pfnGGA)) {
         LOG(QMM_LOG_ERROR, "QMM") << fmt::format("mod_load(\"{}\"): \"GetGameAPI\" function failed\n", mod.path);
         goto fail;
     }
@@ -238,7 +238,7 @@ static bool s_mod_load_vmmain(mod& mod) {
     mod.vmbase = 0;
 
     // pass the vmMain function pointer to the game-specific mod load handler
-    if (g_gameinfo.game->pfnModLoad && !g_gameinfo.game->pfnModLoad((void*)pfnvmMain)) {
+    if (g_gameinfo.game->funcs->pfnModLoad && !g_gameinfo.game->funcs->pfnModLoad((void*)pfnvmMain)) {
         LOG(QMM_LOG_ERROR, "QMM") << fmt::format("mod_load(\"{}\"): Mod load failed?\n", mod.path);
         goto fail;
     }

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -283,7 +283,7 @@ static int s_plugin_helper_IsQVM(plugin_id plid [[maybe_unused]]) {
 
 
 static const char* s_plugin_helper_EngMsgName(plugin_id plid [[maybe_unused]], intptr_t msg) {
-    const char* ret = g_gameinfo.game->eng_msg_names(msg);
+    const char* ret = g_gameinfo.game->funcs->pfnEngMsgNames(msg);
 
 #ifdef _DEBUG
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("Plugin pfnEngMsgName(\"{}\", {}) = \"{}\"\n", ((plugin_info*)plid)->name, msg, ret);
@@ -294,7 +294,7 @@ static const char* s_plugin_helper_EngMsgName(plugin_id plid [[maybe_unused]], i
 
 
 static const char* s_plugin_helper_ModMsgName(plugin_id plid [[maybe_unused]], intptr_t msg) {
-    const char* ret = g_gameinfo.game->mod_msg_names(msg);
+    const char* ret = g_gameinfo.game->funcs->pfnModMsgNames(msg);
 
 #ifdef _DEBUG
     LOG(QMM_LOG_DEBUG, "QMM") << fmt::format("Plugin pfnModMsgName(\"{}\", {}) = \"{}\"\n", ((plugin_info*)plid)->name, msg, ret);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -208,7 +208,7 @@ std::string str_toupper(std::string str) {
 }
 
 
-int str_stristr(std::string haystack, std::string needle) {
+bool str_stristr(std::string haystack, std::string needle) {
     return str_tolower(haystack).find(str_tolower(needle)) != std::string::npos;
 }
 


### PR DESCRIPTION
When testing with OpenJK to load JAMP, it loads the game dll from inside the pk3 by writing it to a temp file in %temp% named OJK0000.tmp, where the number is a random 4-char hex number.

This obviously fails with QMM's auto-detection system as-is.

Try to split auto-detection functionality into a per-game function that gets called, to let the game support file itself decide if we are loaded as that game. This allows for more dynamic tests instead of the dll name check and exe hints.

Also maybe clean up the entire game API system, like place all the game function pointers into a struct that is referenced in g_supportedgames.