### PR TITLE
Remove uses of "goto" outside of qvm.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ CXXFLAGS := -Wall -pipe -fPIC -std=c++17
 LDFLAGS  := -shared -fPIC
 LDLIBS   :=
 
-REL_CPPFLAGS := $(CPPFLAGS)
+REL_CPPFLAGS := $(CPPFLAGS) -DNDEBUG
 DBG_CPPFLAGS := $(CPPFLAGS) -D_DEBUG
 
 REL_CFLAGS_32 := $(CFLAGS) -m32 -O2 -ffast-math -falign-loops=2 -falign-jumps=2 -falign-functions=2 -fno-strict-aliasing -fstrength-reduce -Werror

--- a/README.md
+++ b/README.md
@@ -9,19 +9,58 @@ Created By: Kevin Masterson < k.m.masterson@gmail.com >
 
 ---
 
+## About QMM
+
 **QMM** is a server-side plugin manager for games based on the Quake 3 (and Quake 2!) engine. It functions similar to [Metamod](http://metamod.org/) for Half-Life and [Metamod:Source](https://www.sourcemm.net/) for the Source engine (Half-Life 2).
 
 Formerly located at `q3mm.org`, `planetquake.com/qmm`, and `sourceforge.net/projects/qmm`.
 
-[How it works](https://github.com/thecybermind/qmm2/wiki/How-QMM-works): It hooks communication between the server engine and the game logic (the mod). It allows for plugins to be loaded in-between which can add or change functionality without having to change the mod itself.
+## Documentation
 
-It supports native DLL/SO mods as well as [QVM](https://github.com/thecybermind/qmm2/wiki/QVM) mods with a complete built-in bytecode virtual machine interpreter.
+For the latest installation documentation, please see the [Installation](https://github.com/thecybermind/qmm2/wiki/Installation) wiki page.
 
-See what games QMM supports on the [Game Support wiki page](https://github.com/thecybermind/qmm2/wiki/Game-support).
+## How It Works
 
-Check out some plugins at the [Plugin List wiki page](https://github.com/thecybermind/qmm2/wiki/Plugin-List).
+QMM hooks communication between the server engine and the game logic (the mod). It allows for plugins to be loaded in-between which can add or change functionality without having to change the mod itself.
 
-***For the latest installation documentation, please see the [GitHub project wiki](https://github.com/thecybermind/qmm2/wiki/Installation).***
+QMM supports native DLL/SO mods as well as [QVM](https://github.com/thecybermind/qmm2/wiki/QVM) mods with a complete built-in bytecode virtual machine interpreter.
+
+See the [How QMM Works](https://github.com/thecybermind/qmm2/wiki/How-QMM-works) wiki page for more information.
+
+## Game Support
+
+QMM supports the following games:
+
+  - Call of Duty (MP)
+  - Call of Duty: United Offensive (MP)
+  - Call of Duty v1.1 (MP)
+  - Medal of Honor: Allied Assault
+  - Medal of Honor: Breakthrough
+  - Medal of Honor: Spearhead
+  - Quake 2
+  - Quake 2 Remastered
+  - Quake 3 Arena
+  - Return to Castle Wolfenstein (MP)
+  - Return to Castle Wolfenstein (SP)
+  - SiN
+  - Soldier of Fortune II: Double Helix (MP)
+  - Soldier of Fortune II: Double Helix (SP)
+  - Star Trek Voyager: Elite Force (SP)
+  - Star Trek Voyager: Elite Force (Holomatch)
+  - Star Trek: Elite Force II
+  - Star Wars Jedi Knight: Jedi Academy (SP)
+  - Star Wars Jedi Knight: Jedi Academy (MP)
+  - Star Wars Jedi Knight II: Jedi Outcast (SP)
+  - Star Wars Jedi Knight II: Jedi Outcast (MP)
+  - Wolfenstein: Enemy Territory
+
+See more info about these games on the [Game Support wiki page](https://github.com/thecybermind/qmm2/wiki/Game-support).
+
+## Plugins
+
+Check out some plugins at the [Plugin List](https://github.com/thecybermind/qmm2/wiki/Plugin-List) wiki page.
+
+## Thanks
 
 QMM uses the following libraries:  
   - [nlohmann/json](https://github.com/nlohmann/json) - for reading the configuration file

--- a/README.md
+++ b/README.md
@@ -62,7 +62,21 @@ Check out some plugins at the [Plugin List](https://github.com/thecybermind/qmm2
 
 ## Thanks
 
+Designed by:
+  - Kevin Masterson
+
+Special thanks to:
+  - Brian Stumm
+  - loupgarou21
+  - nevcairiel
+  - BAILOPAN
+  - Lumpy
+  - para
+  - I have forgotten many since 2004; please let me know!
+		
 QMM uses the following libraries:  
-  - [nlohmann/json](https://github.com/nlohmann/json) - for reading the configuration file
-  - [aixlog](https://github.com/badaix/aixlog) - for logging (including to game console!)
-  - [fmtlib](https://github.com/fmtlib/fmt) - for string formatting
+  - [nlohmann/json](https://github.com/nlohmann/json)
+  - [aixlog](https://github.com/badaix/aixlog)
+  - [fmtlib](https://github.com/fmtlib/fmt)
+
+See the LIBLICENSES file for each of these libraries' licenses.

--- a/include/gameinfo.hpp
+++ b/include/gameinfo.hpp
@@ -134,4 +134,33 @@ struct CGameInfo {
 // Basic information about the cgame for games where the DLL has both game and cgame
 extern CGameInfo cgameinfo;
 
+// RAII class to read a file using engine functions
+struct EngineFileRead {
+    EngineFileRead();
+    ~EngineFileRead();
+
+    /**
+    * @brief Open file.
+    *
+    * @param path Filename to open
+    * @return Pointer to contents of file
+    */
+    uint8_t* Open(std::string path);
+
+    /**
+    * @brief Size of file.
+    *
+    * @return File size
+    */
+    int Size();
+
+    /**
+    * @brief Close file.
+    */
+    void Close();
+private:
+    int handle;
+    std::vector<uint8_t> file;
+};
+
 #endif // QMM2_GAMEINFO_H

--- a/include/mod.hpp
+++ b/include/mod.hpp
@@ -37,6 +37,9 @@ struct Mod {
     */
     void Unload();
 
+    // todo: to "own" the dll or vm resource, we need to implement rule of 5
+    // this will assist with RAII during mod loading to remove "goto fail" handlers
+
 private:
     // Entry point into QVM mods. Passed to GameSupport::Entry
     static intptr_t QVM_vmMain(intptr_t cmd, ...);

--- a/include/mod.hpp
+++ b/include/mod.hpp
@@ -18,10 +18,18 @@ Created By:
 
 // A game mod
 struct Mod {
-    std::string path;				// Mod file path
     qvm vm = {};					// QVM object
     void* dll = nullptr;			// OS DLL handle
+    std::string path;				// Mod file path
     APIType api = QMM_API_ERROR;	// API the mod DLL was loaded with
+
+    Mod();
+    ~Mod();
+    // delete copy constructor/assignment since a Mod object owns the DLL pointer and QVM object
+    Mod(const Mod& other) = delete;
+    Mod& operator=(const Mod& other) = delete;
+    Mod(Mod&& other) noexcept;
+    Mod& operator=(Mod&& other) noexcept;
 
     /**
     * @brief Load the given mod file
@@ -43,7 +51,7 @@ private:
     static int QVM_syscall(uint8_t* membase, int cmd, int* args);
 
     /**
-    * @brief Attempt to load Mod::file a QVM mod
+    * @brief Attempt to load a QVM mod
     *
     * @param file Path to QVM mod file
     * @return true if mod load was successful, false otherwise

--- a/include/mod.hpp
+++ b/include/mod.hpp
@@ -21,7 +21,6 @@ struct Mod {
     std::string path;				// Mod file path
     qvm vm = {};					// QVM object
     void* dll = nullptr;			// OS DLL handle
-    intptr_t vmbase = 0;			// Base data segment address for QVMs (0 if DLL mod)
     APIType api = QMM_API_ERROR;	// API the mod DLL was loaded with
 
     /**
@@ -36,10 +35,6 @@ struct Mod {
     * @brief Unload mod file
     */
     void Unload();
-
-    // todo: to "own" the dll or vm resource, we need to implement rule of 5
-    // this will assist with RAII during mod loading to remove "goto fail" handlers
-
 private:
     // Entry point into QVM mods. Passed to GameSupport::Entry
     static intptr_t QVM_vmMain(intptr_t cmd, ...);
@@ -50,17 +45,20 @@ private:
     /**
     * @brief Attempt to load Mod::file a QVM mod
     *
+    * @param file Path to QVM mod file
     * @return true if mod load was successful, false otherwise
     */
-    bool LoadQVM();
+    bool LoadQVM(std::string file);
 
     /**
-    * @brief Attempt to load Mod::file as a DLL mod with the given API type
+    * @brief Attempt to initialize Mod::dll as a DLL mod with the given API type
     *
+    * @param file Path to DLL mod file
+    * @param handle Pointer to loaded DLL
     * @param dll_api API type to load the mod
     * @return true if mod load was successful, false otherwise
     */
-    bool LoadDLL(APIType dll_api);
+    bool InitDLL(std::string file, void* handle, APIType dll_api);
 };
 
 // The game mod

--- a/include/plugin.hpp
+++ b/include/plugin.hpp
@@ -45,8 +45,34 @@ struct Plugin {
     plugin_qvmhandler QMM_QVMHandler = nullptr;         // QMM_QVMHandler function pointer (optional)
     plugin_info* plugininfo = nullptr;                  // Plugin-provided info
 
-    // todo: move plugin_load and plugin_unload to member functions.
-    // also to "own" the dll resource, we need to implement rule of 5
+    Plugin();
+    ~Plugin();
+    Plugin(const Plugin& other) = delete;
+    Plugin& operator=(const Plugin& other) = delete;
+    Plugin(Plugin&& other) noexcept;
+    Plugin& operator=(Plugin&& other) noexcept;
+
+    /**
+    * @brief Load a QMM plugin
+    *
+    * @param file Path to Plugin pDLL
+    * @return >1 if load successful, 0 if file load failed, <0 if plugin loaded but QMM_Attach returned 0
+    */
+    int Load(std::string file);
+
+    /**
+    * @brief Unload a QMM plugin
+    *
+    */
+    void Unload();
+
+    /**
+    * @brief Convert a plugin result flag to string
+    *
+    * @param res Plugin result to convert
+    * @return Converted plugin result
+    */
+    static const char* plugin_result_to_str(plugin_res res);
 };
 
 // This holds global variables that are available to plugins via helper functions.
@@ -67,29 +93,5 @@ constexpr int QMM_QVM_FUNC_STARTING_ID = 10000;
 // This holds pseudo-syscall IDs. They are registered to a given plugin, and when the QVM interpreter executes the
 // syscall ID, the plugin's QMM_QVMHandler function is called.
 extern std::map<int, Plugin*> g_registered_qvm_funcs;
-
-/**
-* @brief Convert a plugin result flag to string
-*
-* @param res Plugin result to convert
-* @return Converted plugin result
-*/
-const char* plugin_result_to_str(plugin_res res);
-
-/**
-* @brief Load a QMM plugin
-*
-* @param p Reference to Plugin object to load
-* @param file Path to Plugin pDLL
-* @return >1 if load successful, 0 if file load failed, <0 if plugin loaded but QMM_Attach returned 0
-*/
-int plugin_load(Plugin& p, std::string file);
-
-/**
-* @brief Unload a QMM plugin
-*
-* @param p Reference to Plugin object to load
-*/
-void plugin_unload(Plugin& p);
 
 #endif // QMM2_PLUGIN_H

--- a/include/plugin.hpp
+++ b/include/plugin.hpp
@@ -47,6 +47,7 @@ struct Plugin {
 
     Plugin();
     ~Plugin();
+    // delete copy constructor/assignment since a Plugin object owns the DLL pointer
     Plugin(const Plugin& other) = delete;
     Plugin& operator=(const Plugin& other) = delete;
     Plugin(Plugin&& other) noexcept;

--- a/include/plugin.hpp
+++ b/include/plugin.hpp
@@ -44,6 +44,9 @@ struct Plugin {
     plugin_pluginmessage QMM_PluginMessage = nullptr;   // QMM_PluginMessage function pointer (optional)
     plugin_qvmhandler QMM_QVMHandler = nullptr;         // QMM_QVMHandler function pointer (optional)
     plugin_info* plugininfo = nullptr;                  // Plugin-provided info
+
+    // todo: move plugin_load and plugin_unload to member functions.
+    // also to "own" the dll resource, we need to implement rule of 5
 };
 
 // This holds global variables that are available to plugins via helper functions.

--- a/include/qvm.h
+++ b/include/qvm.h
@@ -205,6 +205,14 @@ typedef struct {
 extern "C" {
 #endif // __cplusplus
 
+
+/**
+* @brief Initialize a blank VM object.
+*
+* @param vm Pointer to QVM object to initialize
+*/
+void qvm_init(qvm* vm);
+
 /**
 * @brief Create and initialize a new VM from a QVM file.
 * 

--- a/src/game_jk2mp.cpp
+++ b/src/game_jk2mp.cpp
@@ -133,7 +133,7 @@ intptr_t JK2MP_GameSupport::vmMain(intptr_t cmd, ...) {
     // one arg passed to this function is a string that lives in the engine. i don't think this
     // can ever actually be called, but it seems weird this was overlooked for QVM mods by the
     // original engine AND by OpenJK
-    if (cmd == GAME_ROFF_NOTETRACK_CALLBACK && g_mod.vmbase && args[1]) {
+    if (cmd == GAME_ROFF_NOTETRACK_CALLBACK && g_mod.vm.memory && args[1]) {
         // G_ROFF_NotetrackCallback( &g_entities[arg0], (const char *)arg1 );
         size_t arg1len = strlen((char*)args[1]) + 1;
         int arg1 = qvm_hunk_alloc(&g_mod.vm, arg1len, (void*)args[1]);
@@ -146,8 +146,8 @@ intptr_t JK2MP_GameSupport::vmMain(intptr_t cmd, ...) {
 
     // the return value for GAME_CLIENT_CONNECT is a char* so we have to modify the pointer value for QVMs
     // the char* is a string to print if the client should not be allowed to connect, so only change if it's not NULL
-    if (cmd == GAME_CLIENT_CONNECT && ret && g_mod.vmbase) {
-        ret += g_mod.vmbase;
+    if (cmd == GAME_CLIENT_CONNECT && ret && g_mod.vm.memory) {
+        ret += (intptr_t)g_mod.vm.memory;
     }
 
     QMMLOG(QMM_LOG_TRACE, "QMM") << "JK2MP_GameSupport::vmMain(" << ModMsgName(cmd) << "(" << cmd << ")) returning " << ret << "\n";

--- a/src/game_q3a.cpp
+++ b/src/game_q3a.cpp
@@ -133,8 +133,8 @@ intptr_t Q3A_GameSupport::vmMain(intptr_t cmd, ...) {
 
     // the return value for GAME_CLIENT_CONNECT is a char* so we have to modify the pointer value for QVMs
     // the char* is a string to print if the client should not be allowed to connect, so only change if it's not NULL
-    if (cmd == GAME_CLIENT_CONNECT && ret && g_mod.vmbase) {
-        ret += g_mod.vmbase;
+    if (cmd == GAME_CLIENT_CONNECT && ret && g_mod.vm.memory) {
+        ret += (intptr_t)g_mod.vm.memory;
     }
 
     QMMLOG(QMM_LOG_TRACE, "QMM") << "Q3A_GameSupport::vmMain(" << ModMsgName(cmd) << "(" << cmd << ")) returning " << ret << "\n";

--- a/src/game_rtcwmp.cpp
+++ b/src/game_rtcwmp.cpp
@@ -131,7 +131,7 @@ intptr_t RTCWMP_GameSupport::vmMain(intptr_t cmd, ...) {
     // some of the args passed to these mod functions are pointers existing in the engine,
     // which was fine before ioRTCW added qvm support. we can do what ioRTCW did and alloc
     // some space inside the hunk in the qvm data segment and copy the data there and back
-    if (cmd == AICAST_VISIBLEFROMPOS && g_mod.vmbase) {
+    if (cmd == AICAST_VISIBLEFROMPOS && g_mod.vm.memory) {
         // return AICast_VisibleFromPos((float*)arg0, arg1, (float*)arg2, arg3, arg4);
         int arg0 = qvm_hunk_alloc(&g_mod.vm, sizeof(vec3_t), (void*)args[0]);
         int arg2 = qvm_hunk_alloc(&g_mod.vm, sizeof(vec3_t), (void*)args[2]);
@@ -139,13 +139,13 @@ intptr_t RTCWMP_GameSupport::vmMain(intptr_t cmd, ...) {
         qvm_hunk_free(&g_mod.vm, arg2, sizeof(vec3_t), (void*)args[2]);
         qvm_hunk_free(&g_mod.vm, arg0, sizeof(vec3_t), (void*)args[0]);
     }
-    else if (cmd == AICAST_CHECKATTACKATPOS && g_mod.vmbase) {
+    else if (cmd == AICAST_CHECKATTACKATPOS && g_mod.vm.memory) {
         // return AICast_CheckAttackAtPos( arg0, arg1, (float *)arg2, arg3, arg4 );
         int arg2 = qvm_hunk_alloc(&g_mod.vm, sizeof(vec3_t), (void*)args[2]);
         ret = orig_vmMain(cmd, args[0], args[1], arg2, args[3], args[4]);
         qvm_hunk_free(&g_mod.vm, arg2, sizeof(vec3_t), (void*)args[2]);
     }
-    else if (cmd == GAME_RETRIEVE_MOVESPEEDS_FROM_CLIENT && g_mod.vmbase && args[1]) {
+    else if (cmd == GAME_RETRIEVE_MOVESPEEDS_FROM_CLIENT && g_mod.vm.memory && args[1]) {
         // G_RetrieveMoveSpeedsFromClient( arg0, (char *)arg1 );
         size_t arg1len = strlen((char*)args[1]) + 1;
         int arg1 = qvm_hunk_alloc(&g_mod.vm, arg1len, (void*)args[1]);
@@ -159,8 +159,8 @@ intptr_t RTCWMP_GameSupport::vmMain(intptr_t cmd, ...) {
 
     // the return value for GAME_CLIENT_CONNECT is a char* so we have to modify the pointer value for QVMs
     // the char* is a string to print if the client should not be allowed to connect, so only change if it's not NULL
-    if (cmd == GAME_CLIENT_CONNECT && ret && g_mod.vmbase) {
-        ret += g_mod.vmbase;
+    if (cmd == GAME_CLIENT_CONNECT && ret && g_mod.vm.memory) {
+        ret += (intptr_t)g_mod.vm.memory;
     }
 
     QMMLOG(QMM_LOG_TRACE, "QMM") << "RTCWMP_GameSupport::vmMain(" << ModMsgName(cmd) << "(" << cmd << ")) returning " << ret << "\n";

--- a/src/game_sof2mp.cpp
+++ b/src/game_sof2mp.cpp
@@ -137,7 +137,7 @@ intptr_t SOF2MP_GameSupport::vmMain(intptr_t cmd, ...) {
     // some of the args passed to GAME_GAMETYPE_COMMAND are pointers from the gametype QVM. while both the SOF2MP engine
     // and the SOF2GT_QMM plugin will convert them from QVM pointers to real pointers on the way in from the gametype QVM,
     // these are going back into the game QVM, so we need to copy the strings/objects to the qvm hunk
-    if (cmd == GAME_GAMETYPE_COMMAND && g_mod.vmbase) {
+    if (cmd == GAME_GAMETYPE_COMMAND && g_mod.vm.memory) {
         switch (args[0]) {
         // arg1 is a string
         case GTCMD_REGISTERSOUND:       // int  ( const char* soundFile );
@@ -235,8 +235,8 @@ intptr_t SOF2MP_GameSupport::vmMain(intptr_t cmd, ...) {
 
     // the return value for GAME_CLIENT_CONNECT is a char* so we have to modify the pointer value for QVMs
     // the char* is a string to print if the client should not be allowed to connect, so only change if it's not NULL
-    if (cmd == GAME_CLIENT_CONNECT && ret && g_mod.vmbase) {
-        ret += g_mod.vmbase;
+    if (cmd == GAME_CLIENT_CONNECT && ret && g_mod.vm.memory) {
+        ret += (intptr_t)g_mod.vm.memory;
     }
 
     QMMLOG(QMM_LOG_TRACE, "QMM") << "SOF2MP_GameSupport::vmMain(" << ModMsgName(cmd) << "(" << cmd << ")) returning " << ret << "\n";

--- a/src/game_stvoyhm.cpp
+++ b/src/game_stvoyhm.cpp
@@ -137,8 +137,8 @@ intptr_t STVOYHM_GameSupport::vmMain(intptr_t cmd, ...) {
 
     // the return value for GAME_CLIENT_CONNECT is a char* so we have to modify the pointer value for QVMs
     // the char* is a string to print if the client should not be allowed to connect, so only change if it's not NULL
-    if (cmd == GAME_CLIENT_CONNECT && ret && g_mod.vmbase) {
-        ret += g_mod.vmbase;
+    if (cmd == GAME_CLIENT_CONNECT && ret && g_mod.vm.memory) {
+        ret += (intptr_t)g_mod.vm.memory;
     }
 
     QMMLOG(QMM_LOG_TRACE, "QMM") << "STVOYHM_GameSupport::vmMain(" << ModMsgName(cmd) << "(" << cmd << ")) returning " << ret << "\n";

--- a/src/gameinfo.cpp
+++ b/src/gameinfo.cpp
@@ -244,29 +244,27 @@ bool GameInfo::LoadMod(std::string cfg_mod) {
     // "<mod>"
     // "<qmmdir>/<mod>"
     // "<exedir>/<moddir>/<mod>"
-    else {
-        std::vector<std::string> try_paths;
-        // if "mod" config setting was "auto"
-        if (str_striequal(cfg_mod, "auto")) {
-            // treat as if "mod" config setting was "qmm_" plus the default dll name for this engine
-            cfg_mod = fmt::format("qmm_{}", this->game->DefaultDLLName());
-            // add QVM filename to search list if this game supports it
-            if (this->game->DefaultQVMName())
-                try_paths.push_back(this->game->DefaultQVMName());
-        }
-        // if "mod" config setting was a relative path, do nothing special unless QVM
-        if (str_striequal(path_baseext(cfg_mod), EXT_QVM) && this->game->DefaultQVMName())
-            try_paths.push_back(cfg_mod);
-        try_paths.push_back(fmt::format("{}/{}", this->qmm_dir, cfg_mod));
-        try_paths.push_back(fmt::format("{}/{}/{}", this->exe_dir, this->mod_dir, cfg_mod));
-        for (std::string& try_path : try_paths) {
-            try_path = path_normalize(try_path);
-            if (try_path.empty() || !path_is_allowed(try_path))
-                continue;
-            QMMLOG(QMM_LOG_INFO, "QMM") << "Attempting to load mod \"" << try_path << "\"\n";
-            if (g_mod.Load(try_path))
-                return true;
-        }
+    std::vector<std::string> try_paths;
+    // if "mod" config setting was "auto"
+    if (str_striequal(cfg_mod, "auto")) {
+        // treat as if "mod" config setting was "qmm_" plus the default dll name for this engine
+        cfg_mod = fmt::format("qmm_{}", this->game->DefaultDLLName());
+        // add QVM filename to search list if this game supports it
+        if (this->game->DefaultQVMName())
+            try_paths.push_back(this->game->DefaultQVMName());
+    }
+    // if "mod" config setting was a relative path, do nothing special unless QVM
+    if (str_striequal(path_baseext(cfg_mod), EXT_QVM) && this->game->DefaultQVMName())
+        try_paths.push_back(cfg_mod);
+    try_paths.push_back(fmt::format("{}/{}", this->qmm_dir, cfg_mod));
+    try_paths.push_back(fmt::format("{}/{}/{}", this->exe_dir, this->mod_dir, cfg_mod));
+    for (std::string& try_path : try_paths) {
+        try_path = path_normalize(try_path);
+        if (try_path.empty() || !path_is_allowed(try_path))
+            continue;
+        QMMLOG(QMM_LOG_INFO, "QMM") << "Attempting to load mod \"" << try_path << "\"\n";
+        if (g_mod.Load(try_path))
+            return true;
     }
 
     return false;
@@ -278,8 +276,8 @@ bool GameInfo::LoadPlugin(std::string plugin_path) {
     // absolute path, just attempt to load it directly
     if (path_is_absolute(plugin_path)) {
         // plugin_load returns 0 if no plugin file was found, 1 if success, and -1 if file was found but failure
-        if (plugin_load(p, plugin_path) > 0) {
-            g_plugins.push_back(p);
+        if (p.Load(plugin_path) > 0) {
+            g_plugins.push_back(std::move(p));
             return true;
         }
         return false;
@@ -296,12 +294,16 @@ bool GameInfo::LoadPlugin(std::string plugin_path) {
         if (try_path.empty() || !path_is_allowed(try_path))
             continue;
         // plugin_load returns 0 if no plugin file was found, 1 if success, and -1 if file was found but failure
-        int ret = plugin_load(p, try_path);
+        int ret = p.Load(try_path);
         if (ret > 0) {
-            g_plugins.push_back(p);
+            g_plugins.push_back(std::move(p));
             return true;
         }
-        if (ret < 0)
+        // file not found, bad DLL, or not a valid plugin DLL
+        else if (ret == 0)
+            continue;
+        // path was to a valid plugin DLL, but shouldn't be loaded
+        else if (ret < 0)
             return false;
     }
 
@@ -349,7 +351,7 @@ intptr_t GameInfo::Route(bool is_syscall, intptr_t cmd, intptr_t* args) const {
         else
             plugin_ret = p.QMM_vmMain(cmd, args);
 
-        QMMLOG(QMM_LOG_TRACE, "QMM") << "Plugin \"" << p.plugininfo->name << "\" QMM_" << func_name << "( " << msg_name << "(" << cmd << ")) returning " << plugin_ret << " with result " << plugin_result_to_str(g_plugin_globals.plugin_result) << "\n";
+        QMMLOG(QMM_LOG_TRACE, "QMM") << "Plugin \"" << p.plugininfo->name << "\" QMM_" << func_name << "( " << msg_name << "(" << cmd << ")) returning " << plugin_ret << " with result " << Plugin::plugin_result_to_str(g_plugin_globals.plugin_result) << "\n";
 
         // set new max result
         max_result = util_max(g_plugin_globals.plugin_result, max_result);
@@ -404,7 +406,7 @@ intptr_t GameInfo::Route(bool is_syscall, intptr_t cmd, intptr_t* args) const {
         else
             plugin_ret = p.QMM_vmMain_Post(cmd, args);
 
-        QMMLOG(QMM_LOG_TRACE, "QMM") << "Plugin \"" << p.plugininfo->name << "\" QMM_" << func_name << "_Post( " << msg_name << "(" << cmd << ")) returning " << plugin_ret << " with result " << plugin_result_to_str(g_plugin_globals.plugin_result) << "\n";
+        QMMLOG(QMM_LOG_TRACE, "QMM") << "Plugin \"" << p.plugininfo->name << "\" QMM_" << func_name << "_Post( " << msg_name << "(" << cmd << ")) returning " << plugin_ret << " with result " << Plugin::plugin_result_to_str(g_plugin_globals.plugin_result) << "\n";
 
         // ignore QMM_UNUSED so plugins can just use return, but still show a message for QMM_ERROR
         if (g_plugin_globals.plugin_result == QMM_ERROR) {
@@ -420,4 +422,38 @@ intptr_t GameInfo::Route(bool is_syscall, intptr_t cmd, intptr_t* args) const {
     g_plugin_globals = old_globals;
 
     return final_ret;
+}
+
+
+EngineFileRead::EngineFileRead() : handle(0) {
+}
+
+
+uint8_t* EngineFileRead::Open(std::string path) {
+    intptr_t filelen = ENG_SYSCALL(QMM_ENG_MSG(QMM_G_FS_FOPEN_FILE), path.c_str(), &this->handle, QMM_ENG_MSG(QMM_FS_READ));
+    if (filelen <= 0 || !this->handle) {
+        this->Close();
+        return nullptr;
+    }
+    this->file.resize((size_t)filelen);
+    ENG_SYSCALL(QMM_ENG_MSG(QMM_G_FS_READ), this->file.data(), this->file.size(), this->handle);
+    return this->file.data();
+}
+
+
+int EngineFileRead::Size() {
+    return this->file.size();
+}
+
+
+void EngineFileRead::Close() {
+    this->file.clear();
+    if (handle)
+        ENG_SYSCALL(QMM_ENG_MSG(QMM_G_FS_FCLOSE_FILE), this->handle);
+    this->handle = 0;
+}
+
+
+EngineFileRead::~EngineFileRead() {
+    this->Close();
 }

--- a/src/gameinfo.cpp
+++ b/src/gameinfo.cpp
@@ -442,7 +442,7 @@ uint8_t* EngineFileRead::Open(std::string path) {
 
 
 int EngineFileRead::Size() {
-    return this->file.size();
+    return (int)this->file.size();
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -247,9 +247,11 @@ C_DLLEXPORT intptr_t vmMain(intptr_t cmd, ...) {
         // check command line arguments for a mod filename
         cfg_mod = util_get_cmdline_arg("--qmm_mod", cfg_mod);
         if (!gameinfo.LoadMod(cfg_mod)) {
-            gameinfo.is_shutdown = true;
-            QMMLOG(QMM_LOG_FATAL, "QMM") << "vmMain(" << gameinfo.game->ModMsgName(cmd) << "): Unable to load mod using \"" << cfg_mod << "\"\n";
-            ENG_SYSCALL(QMM_FAIL_G_ERROR, "\nFatal QMM Error:\nQMM was unable to load the mod file.\nPlease set the \"mod\" option in qmm2.json.\nRefer to the documentation for more information.\n");
+            if (!gameinfo.is_shutdown) {
+                gameinfo.is_shutdown = true;
+                QMMLOG(QMM_LOG_FATAL, "QMM") << "QMM was unable to load the mod file using \"" << cfg_mod << "\". Please set the \"mod\" option in qmm2.json. Refer to the documentation for more information.\n";
+                ENG_SYSCALL(QMM_ENG_MSG(QMM_G_ERROR), "\nFatal QMM Error:\nQMM was unable to load the mod file.\nPlease set the \"mod\" option in qmm2.json.\nRefer to the documentation for more information.\n");
+            }
             return 0;
         }
         QMMLOG(QMM_LOG_NOTICE, "QMM") << "Successfully loaded " << APIType_Function(g_mod.api) << " mod \"" << g_mod.path << "\"\n";
@@ -440,6 +442,25 @@ static void HandleQMMCommand(intptr_t arg_start) {
         g_cfg = cfg_load(gameinfo.cfg_path);
         CONSOLE_PRINT("(QMM) Configuration file reloaded!\n");
     }
+    else if (str_striequal("credits", arg1) || str_striequal("thanks", arg1)) {
+        CONSOLE_PRINT("(QMM) QMM credits:\n");
+        CONSOLE_PRINT("(QMM) Designed by:\n");
+        CONSOLE_PRINT("(QMM)  - Kevin Masterson\n");
+        CONSOLE_PRINT("(QMM)\n");
+        CONSOLE_PRINT("(QMM) Special thanks to:\n");
+        CONSOLE_PRINT("(QMM)  - BAStumm\n");
+        CONSOLE_PRINT("(QMM)  - loupgarou21\n");
+        CONSOLE_PRINT("(QMM)  - nevcairiel\n");
+        CONSOLE_PRINT("(QMM)  - BAILOPAN\n");
+        CONSOLE_PRINT("(QMM)  - Lumpy\n");
+        CONSOLE_PRINT("(QMM)  - para\n");
+        CONSOLE_PRINT("(QMM)  - I have forgotten many since 2004; please let me know!\n");
+        CONSOLE_PRINT("(QMM)\n");
+        CONSOLE_PRINT("(QMM) QMM uses the following libraries:\n");
+        CONSOLE_PRINT("(QMM)  - nlohmann/json - https://github.com/nlohmann/json\n");
+        CONSOLE_PRINT("(QMM)  - aixlog - https://github.com/badaix/aixlog\n");
+        CONSOLE_PRINT("(QMM)  - fmtlib - https://github.com/fmtlib/fmt\n");
+    }
     else {
         CONSOLE_PRINT("(QMM) Usage: qmm <command> [params]\n");
         CONSOLE_PRINT("(QMM) Available commands:\n");
@@ -448,6 +469,7 @@ static void HandleQMMCommand(intptr_t arg_start) {
         CONSOLE_PRINT("(QMM) qmm plugin <id> - outputs info on plugin with id\n");
         CONSOLE_PRINT("(QMM) qmm loglevel <level> - changes QMM log level: TRACE, DEBUG, INFO, NOTICE, WARNING, ERROR, FATAL\n");
         CONSOLE_PRINT("(QMM) qmm reload - reloads the QMM configuration file\n");
+        CONSOLE_PRINT("(QMM) qmm credits - QMM credits\n");
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -334,7 +334,7 @@ C_DLLEXPORT intptr_t vmMain(intptr_t cmd, ...) {
         // unload each plugin (call QMM_Detach, and then dlclose)
         QMMLOG(QMM_LOG_NOTICE, "QMM") << "Shutting down plugins\n";
         for (Plugin& p : g_plugins) {
-            plugin_unload(p);
+            p.Unload();
         }
         g_plugins.clear();
 
@@ -379,7 +379,7 @@ static void HandleQMMCommand(intptr_t arg_start) {
         CONSOLE_PRINT ("(QMM) PIFV       : " STRINGIFY(QMM_PIFV_MAJOR) ":" STRINGIFY(QMM_PIFV_MINOR) "\n");
         CONSOLE_PRINTF("(QMM) Plugins    : {}\n", g_plugins.size());
         CONSOLE_PRINTF("(QMM) Loaded mod : {} ({})\n", g_mod.path, APIType_Function(g_mod.api));
-        if (g_mod.vmbase) {
+        if (g_mod.vm.memory) {
             CONSOLE_PRINT ("(QMM)\n");
             CONSOLE_PRINT ("(QMM) QVM mod information\n");
             CONSOLE_PRINT ("(QMM) -------------------\n");

--- a/src/mod.cpp
+++ b/src/mod.cpp
@@ -32,49 +32,40 @@ bool Mod::Load(std::string file) {
     if (this->dll || this->vm.memory)
         this->Unload();
 
-    this->path = file;
-
     std::string ext = path_baseext(file);
 
     // only allow qvm mods if the game engine supports it
     if (str_striequal(ext, EXT_QVM) && gameinfo.game->DefaultQVMName()) {
-        if (!this->LoadQVM())
-            goto fail;
-        return true;
+        return this->LoadQVM(file);
     }
     // if DLL
     else if (str_striequal(ext, EXT_DLL)) {
         // load DLL
-        this->dll = dll_load(file.c_str());
-        if (!this->dll) {
+        void* handle = dll_load(file.c_str());
+        if (!handle) {
             QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::Load(\"" << file << "\"): DLL load failed: " << dll_error() << "\n";
-            goto fail;
+            return false;
         }
 
         // if this DLL is the same as QMM, cancel
-        if (this->dll == gameinfo.qmm_module_ptr) {
+        if (handle == gameinfo.qmm_module_ptr) {
             QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::Load(\"" << path_basename(file) << "\"): DLL is actually QMM?\n";
-            goto fail;
+            return false;
         }
 
-        this->vmbase = 0;
-
-        if (this->LoadDLL(QMM_API_GETGAMEAPI))
+        if (this->InitDLL(file, handle, QMM_API_GETGAMEAPI))
             return true;
-        if (this->LoadDLL(QMM_API_GETMODULEAPI))
+        if (this->InitDLL(file, handle, QMM_API_GETMODULEAPI))
             return true;
-        if (this->LoadDLL(QMM_API_DLLENTRY))
+        if (this->InitDLL(file, handle, QMM_API_DLLENTRY))
             return true;
 
         QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::Load(\"" << path_basename(file) << "\"): Unable to locate mod entry point\n";
-        goto fail;
     }
     else {
         QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::Load(\"" << path_basename(file) << "\"): Unknown mod file format\n";
     }
 
-fail:
-    this->Unload();
     return false;
 }
 
@@ -142,45 +133,15 @@ int Mod::QVM_syscall(uint8_t* membase, int cmd, int* args) {
 }
 
 
-struct EngineFileRead {
-    EngineFileRead() : handle(0) {}
-    uint8_t* Open(std::string path) {
-        intptr_t filelen = ENG_SYSCALL(QMM_ENG_MSG(QMM_G_FS_FOPEN_FILE), path.c_str(), &this->handle, QMM_ENG_MSG(QMM_FS_READ));
-        if (filelen <= 0 || !this->handle) {
-            this->Close();
-            return nullptr;
-        }
-        this->file.resize((size_t)filelen);
-        ENG_SYSCALL(QMM_ENG_MSG(QMM_G_FS_READ), this->file.data(), this->file.size(), this->handle);
-        return this->file.data();
-    }
-    int Size() {
-        return this->file.size();
-    }
-    void Close() {
-        this->file.clear();
-        if (handle)
-            ENG_SYSCALL(QMM_ENG_MSG(QMM_G_FS_FCLOSE_FILE), this->handle);
-        this->handle = 0;
-    }
-    ~EngineFileRead() {
-        this->Close();
-    }
-private:
-    int handle;
-    std::vector<uint8_t> file;
-};
-
-
-bool Mod::LoadQVM() {
-    EngineFileRead file;
+bool Mod::LoadQVM(std::string file) {
+    EngineFileRead f;
     bool verify_data;
     size_t hunk_size;
 
     // load file using engine functions to read into pk3s if necessary
-    uint8_t* filedata = file.Open(this->path);
+    uint8_t* filedata = f.Open(file);
     if (!filedata) {
-        QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::LoadQVM(\"" << this->path << "\"): Could not open QVM for reading\n";
+        QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::LoadQVM(\"" << file << "\"): Could not open QVM for reading\n";
         return false;
     }
 
@@ -190,62 +151,62 @@ bool Mod::LoadQVM() {
     hunk_size = (size_t)cfg_get_int(g_cfg, "qvmhunksize", 0);
 
     // attempt to load mod
-    if (!qvm_load(&this->vm, filedata, file.Size(), Mod::QVM_syscall, verify_data, hunk_size, nullptr)) {
-        QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::LoadQVM(\"" << this->path << "\"): QVM load failed\n";
+    if (!qvm_load(&this->vm, filedata, f.Size(), Mod::QVM_syscall, verify_data, hunk_size, nullptr)) {
+        QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::LoadQVM(\"" << file << "\"): QVM load failed\n";
         return false;
     }
-
-    this->vmbase = (intptr_t)this->vm.datasegment;
 
     // pass the qvm vmMain function pointer to the game-specific mod load handler
     if (!gameinfo.game->ModLoad((void*)Mod::QVM_vmMain, QMM_API_QVM)) {
-        QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::LoadQVM(\"" << path_basename(this->path) << "\"): Mod load failed?\n";
+        QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::LoadQVM(\"" << path_basename(file) << "\"): Mod load failed?\n";
         return false;
     }
 
-    this->api = QMM_API_QVM;
+    QMMLOG(QMM_LOG_DEBUG, "QMM") << "Mod::LoadQVM(\"" << path_basename(file) << "\"): QVM loaded successfully with verify_data " << (this->vm.verify_data ? "on" : "off") << " and hunk size " << this->vm.hunksize << "\n";
 
-    QMMLOG(QMM_LOG_DEBUG, "QMM") << "Mod::LoadQVM(\"" << path_basename(this->path) << "\"): QVM loaded successfully with verify_data " << (this->vm.verify_data ? "on" : "off") << " and hunk size " << this->vm.hunksize << "\n";
+    this->api = QMM_API_QVM;
+    this->path = file;
 
     return true;
 }
 
 
-bool Mod::LoadDLL(APIType dll_api) {
-    this->api = dll_api;
-
+bool Mod::InitDLL(std::string file, void* handle, APIType dll_api) {
     switch (dll_api) {
     case QMM_API_GETGAMEAPI:
     case QMM_API_GETMODULEAPI: {
         // these are together because they work the same, just with a different function name
 
         // look for GetGameAPI/GetModuleAPI function
-        mod_GetGameAPI pfnGGA = (mod_GetGameAPI)dll_symbol(this->dll, APIType_Function(dll_api));
+        mod_GetGameAPI pfnGGA = (mod_GetGameAPI)dll_symbol(handle, APIType_Function(dll_api));
         if (!pfnGGA) {
-            QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::LoadDLL(\"" << path_basename(this->path) << "\"): Could not locate mod entry point \"" << APIType_Function(dll_api) << "\"\n";
+            QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::InitDLL(\"" << path_basename(file) << "\"): Could not locate mod entry point \"" << APIType_Function(dll_api) << "\"\n";
             return false;
         }
 
         // pass GGA/GMA function to game-specific mod load handler
         if (gameinfo.game->ModLoad((void*)pfnGGA, dll_api)) {
             // if mod load handler says good to go, we do too
+            this->api = dll_api;
+            this->dll = handle;
+            this->path = file;
             return true;
         }
 
-        QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::LoadDLL(\"" << path_basename(this->path) << "\"): " << gameinfo.game->GameCode() << "_GameSupport::ModLoad returned false\n";
+        QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::InitDLL(\"" << path_basename(file) << "\"): " << gameinfo.game->GameCode() << "_GameSupport::ModLoad returned false\n";
 
         return false;
     }
     case QMM_API_DLLENTRY: {
-        mod_dllEntry pfndllEntry = (mod_dllEntry)dll_symbol(this->dll, "dllEntry");
+        mod_dllEntry pfndllEntry = (mod_dllEntry)dll_symbol(handle, "dllEntry");
         if (!pfndllEntry) {
-            QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::LoadDLL(\"" << path_basename(this->path) << "\"): Could not locate mod entry point \"dllEntry\"\n";
+            QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::InitDLL(\"" << path_basename(file) << "\"): Could not locate mod entry point \"dllEntry\"\n";
             return false;
         }
 
-        mod_vmMain pfnvmMain = (mod_vmMain)dll_symbol(this->dll, "vmMain");
+        mod_vmMain pfnvmMain = (mod_vmMain)dll_symbol(handle, "vmMain");
         if (!pfnvmMain) {
-            QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::LoadDLL(\"" << path_basename(this->path) << "\"): Could not locate mod entry point \"vmMain\"\n";
+            QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::InitDLL(\"" << path_basename(file) << "\"): Could not locate mod entry point \"vmMain\"\n";
             return false;
         }
 
@@ -253,10 +214,13 @@ bool Mod::LoadDLL(APIType dll_api) {
         if (gameinfo.game->ModLoad((void*)pfnvmMain, dll_api)) {
             // if mod load handler says good to go, we also need to pass qmm_syscall to mod's dllEntry function
             pfndllEntry(qmm_syscall);
+            this->api = dll_api;
+            this->dll = handle;
+            this->path = file;
             return true;
         }
 
-        QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::LoadDLL(\"" << path_basename(this->path) << "\"): " << gameinfo.game->GameCode() << "_GameSupport::ModLoad returned false\n";
+        QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::InitDLL(\"" << path_basename(file) << "\"): " << gameinfo.game->GameCode() << "_GameSupport::ModLoad returned false\n";
 
         return false;
     }

--- a/src/mod.cpp
+++ b/src/mod.cpp
@@ -38,7 +38,9 @@ bool Mod::Load(std::string file) {
 
     // only allow qvm mods if the game engine supports it
     if (str_striequal(ext, EXT_QVM) && gameinfo.game->DefaultQVMName()) {
-        return this->LoadQVM();
+        if (!this->LoadQVM())
+            goto fail;
+        return true;
     }
     // if DLL
     else if (str_striequal(ext, EXT_DLL)) {
@@ -140,26 +142,47 @@ int Mod::QVM_syscall(uint8_t* membase, int cmd, int* args) {
 }
 
 
+struct EngineFileRead {
+    EngineFileRead() : handle(0) {}
+    uint8_t* Open(std::string path) {
+        intptr_t filelen = ENG_SYSCALL(QMM_ENG_MSG(QMM_G_FS_FOPEN_FILE), path.c_str(), &this->handle, QMM_ENG_MSG(QMM_FS_READ));
+        if (filelen <= 0 || !this->handle) {
+            this->Close();
+            return nullptr;
+        }
+        this->file.resize((size_t)filelen);
+        ENG_SYSCALL(QMM_ENG_MSG(QMM_G_FS_READ), this->file.data(), this->file.size(), this->handle);
+        return this->file.data();
+    }
+    int Size() {
+        return this->file.size();
+    }
+    void Close() {
+        this->file.clear();
+        if (handle)
+            ENG_SYSCALL(QMM_ENG_MSG(QMM_G_FS_FCLOSE_FILE), this->handle);
+        this->handle = 0;
+    }
+    ~EngineFileRead() {
+        this->Close();
+    }
+private:
+    int handle;
+    std::vector<uint8_t> file;
+};
+
+
 bool Mod::LoadQVM() {
-    int fpk3 = 0;
-    intptr_t filelen;
-    std::vector<uint8_t> filemem;
+    EngineFileRead file;
     bool verify_data;
-    size_t hunk_size = 0;
-    bool loaded;
+    size_t hunk_size;
 
     // load file using engine functions to read into pk3s if necessary
-    filelen = ENG_SYSCALL(QMM_ENG_MSG(QMM_G_FS_FOPEN_FILE), this->path.c_str(), &fpk3, QMM_ENG_MSG(QMM_FS_READ));
-    if (filelen <= 0 || !fpk3) {
+    uint8_t* filedata = file.Open(this->path);
+    if (!filedata) {
         QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::LoadQVM(\"" << this->path << "\"): Could not open QVM for reading\n";
-        if (fpk3)
-            ENG_SYSCALL(QMM_ENG_MSG(QMM_G_FS_FCLOSE_FILE), fpk3);
-        goto fail;
+        return false;
     }
-    filemem.resize((size_t)filelen);
-
-    ENG_SYSCALL(QMM_ENG_MSG(QMM_G_FS_READ), filemem.data(), filelen, fpk3);
-    ENG_SYSCALL(QMM_ENG_MSG(QMM_G_FS_FCLOSE_FILE), fpk3);
 
     // get data verification setting from config
     verify_data = cfg_get_bool(g_cfg, "qvmverifydata", true);
@@ -167,19 +190,17 @@ bool Mod::LoadQVM() {
     hunk_size = (size_t)cfg_get_int(g_cfg, "qvmhunksize", 0);
 
     // attempt to load mod
-    loaded = qvm_load(&this->vm, filemem.data(), filemem.size(), Mod::QVM_syscall, verify_data, hunk_size, nullptr);
-    if (!loaded) {
+    if (!qvm_load(&this->vm, filedata, file.Size(), Mod::QVM_syscall, verify_data, hunk_size, nullptr)) {
         QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::LoadQVM(\"" << this->path << "\"): QVM load failed\n";
-        goto fail;
+        return false;
     }
 
     this->vmbase = (intptr_t)this->vm.datasegment;
 
     // pass the qvm vmMain function pointer to the game-specific mod load handler
-    if (!gameinfo.game->ModLoad((void*)Mod::QVM_vmMain, QMM_API_QVM))
-    {
+    if (!gameinfo.game->ModLoad((void*)Mod::QVM_vmMain, QMM_API_QVM)) {
         QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::LoadQVM(\"" << path_basename(this->path) << "\"): Mod load failed?\n";
-        goto fail;
+        return false;
     }
 
     this->api = QMM_API_QVM;
@@ -187,10 +208,6 @@ bool Mod::LoadQVM() {
     QMMLOG(QMM_LOG_DEBUG, "QMM") << "Mod::LoadQVM(\"" << path_basename(this->path) << "\"): QVM loaded successfully with verify_data " << (this->vm.verify_data ? "on" : "off") << " and hunk size " << this->vm.hunksize << "\n";
 
     return true;
-
-fail:
-    this->Unload();
-    return false;
 }
 
 

--- a/src/mod.cpp
+++ b/src/mod.cpp
@@ -27,6 +27,38 @@ Created By:
 Mod g_mod;
 
 
+Mod::Mod() : vm({}), dll(nullptr), api(QMM_API_ERROR) {
+}
+
+
+Mod::~Mod() {
+    this->Unload();
+}
+
+
+Mod::Mod(Mod&& other) noexcept : Mod() {
+    if (this == &other)
+        return;
+
+    *this = std::move(other);
+}
+
+
+Mod& Mod::operator=(Mod&& other) noexcept {
+    if (this == &other)
+        return *this;
+
+    // swap since a Mod "owns" the QVM
+    std::swap(this->vm, other.vm);
+    // swap since a Mod "owns" the dll handle
+    std::swap(this->dll, other.dll);
+    this->path = other.path;
+    this->api = other.api;
+
+    return *this;
+}
+
+
 bool Mod::Load(std::string file) {
     // if this mod somehow already has a dll or qvm pointer, wipe it first
     if (this->dll || this->vm.memory)
@@ -72,11 +104,14 @@ bool Mod::Load(std::string file) {
 
 void Mod::Unload() {
     // call the game-specific mod unload callback
-    gameinfo.game->ModUnload();
-    qvm_unload(&this->vm);
+    if (gameinfo.game)
+        gameinfo.game->ModUnload();
     if (this->dll)
         dll_close(this->dll);
-    *this = Mod();
+    qvm_unload(&this->vm);
+    qvm_init(&this->vm);
+    this->dll = nullptr;
+    this->api = QMM_API_ERROR;
 }
 
 

--- a/src/mod.cpp
+++ b/src/mod.cpp
@@ -92,7 +92,7 @@ bool Mod::Load(std::string file) {
         if (this->InitDLL(file, handle, QMM_API_DLLENTRY))
             return true;
 
-        QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::Load(\"" << path_basename(file) << "\"): Unable to locate mod entry point\n";
+        QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::Load(\"" << path_basename(file) << "\"): Unable to locate a valid mod entry point\n";
     }
     else {
         QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::Load(\"" << path_basename(file) << "\"): Unknown mod file format\n";
@@ -103,14 +103,13 @@ bool Mod::Load(std::string file) {
 
 
 void Mod::Unload() {
-    // call the game-specific mod unload callback
-    if (gameinfo.game)
+    // call the game-specific mod unload callback only if a mod was actually loaded
+    if (gameinfo.game && (this->dll || this->vm.memory))
         gameinfo.game->ModUnload();
-    if (this->dll)
-        dll_close(this->dll);
+    dll_close(this->dll);
+    this->dll = nullptr;
     qvm_unload(&this->vm);
     qvm_init(&this->vm);
-    this->dll = nullptr;
     this->api = QMM_API_ERROR;
 }
 
@@ -194,6 +193,8 @@ bool Mod::LoadQVM(std::string file) {
     // pass the qvm vmMain function pointer to the game-specific mod load handler
     if (!gameinfo.game->ModLoad((void*)Mod::QVM_vmMain, QMM_API_QVM)) {
         QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::LoadQVM(\"" << path_basename(file) << "\"): Mod load failed?\n";
+        // call ModUnload to allow game support code to reset
+        gameinfo.game->ModUnload();
         return false;
     }
 
@@ -228,6 +229,9 @@ bool Mod::InitDLL(std::string file, void* handle, APIType dll_api) {
             return true;
         }
 
+        // call ModUnload to allow game support code to reset
+        gameinfo.game->ModUnload();
+
         QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::InitDLL(\"" << path_basename(file) << "\"): " << gameinfo.game->GameCode() << "_GameSupport::ModLoad returned false\n";
 
         return false;
@@ -254,6 +258,9 @@ bool Mod::InitDLL(std::string file, void* handle, APIType dll_api) {
             this->path = file;
             return true;
         }
+
+        // call ModUnload to allow game support code to reset
+        gameinfo.game->ModUnload();
 
         QMMLOG(QMM_LOG_ERROR, "QMM") << "Mod::InitDLL(\"" << path_basename(file) << "\"): " << gameinfo.game->GameCode() << "_GameSupport::ModLoad returned false\n";
 

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -145,11 +145,13 @@ Plugin& Plugin::operator=(Plugin&& other) noexcept {
     if (this == &other)
         return *this;
 
+    // swap since a Plugin "owns" the dll handle
     std::swap(this->dll, other.dll);
     this->path = other.path;
     this->QMM_Query = other.QMM_Query;
     this->QMM_Attach = other.QMM_Attach;
-    this->QMM_Detach = other.QMM_Detach;
+    // swap since QMM_Detach is called for an unloading plugin in Unload/destructor
+    std::swap(this->QMM_Detach, other.QMM_Detach);
     this->QMM_vmMain = other.QMM_vmMain;
     this->QMM_vmMain_Post = other.QMM_vmMain_Post;
     this->QMM_syscall = other.QMM_syscall;
@@ -261,6 +263,7 @@ int Plugin::Load(std::string file) {
     }
 
     this->path = file;
+    // optional plugin functions
     this->QMM_PluginMessage = (Plugin::plugin_pluginmessage)dll_symbol(this->dll, "QMM_PluginMessage");
     this->QMM_QVMHandler = (Plugin::plugin_qvmhandler)dll_symbol(this->dll, "QMM_QVMHandler");
 
@@ -269,11 +272,9 @@ int Plugin::Load(std::string file) {
 
 
 void Plugin::Unload() {
-    if (this->dll) {
-        if (this->QMM_Detach)
-            this->QMM_Detach();
-        dll_close(this->dll);
-    }
+    if (this->dll && this->QMM_Detach)
+        this->QMM_Detach();
+    dll_close(this->dll);
     this->dll = nullptr;
     this->path.clear();
     this->QMM_Query = nullptr;

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -107,19 +107,6 @@ static plugin_vars s_pluginvars = {
 };
 
 
-const char* plugin_result_to_str(plugin_res res) {
-    switch (res) {
-        GEN_CASE(QMM_UNUSED);
-        GEN_CASE(QMM_ERROR);
-        GEN_CASE(QMM_IGNORED);
-        GEN_CASE(QMM_OVERRIDE);
-        GEN_CASE(QMM_SUPERCEDE);
-    default:
-        return "unknown";
-    };
-}
-
-
 // Wrapper syscall function to pass to plugins
 static intptr_t s_plugin_game_syscall(intptr_t cmd, ...) {
     QMM_GET_SYSCALL_ARGS();
@@ -134,130 +121,184 @@ static intptr_t s_plugin_game_vmMain(intptr_t cmd, ...) {
 }
 
 
-int plugin_load(Plugin& p, std::string file) {
-    int ret = 0;
+Plugin::Plugin() : dll(nullptr), QMM_Query(nullptr), QMM_Attach(nullptr), QMM_Detach(nullptr),
+    QMM_vmMain(nullptr), QMM_vmMain_Post(nullptr), QMM_syscall(nullptr), QMM_syscall_Post(nullptr),
+    QMM_PluginMessage(nullptr), QMM_QVMHandler(nullptr), plugininfo(nullptr)
+{
+}
 
-    // if this plugin somehow already has a dll pointer, wipe it first
-    if (p.dll)
-        plugin_unload(p);
+
+Plugin::~Plugin() {
+    this->Unload();
+}
+
+
+Plugin::Plugin(Plugin&& other) noexcept : Plugin() {
+    if (this == &other)
+        return;
+
+    *this = std::move(other);
+}
+
+
+Plugin& Plugin::operator=(Plugin&& other) noexcept {
+    if (this == &other)
+        return *this;
+
+    std::swap(this->dll, other.dll);
+    this->path = other.path;
+    this->QMM_Query = other.QMM_Query;
+    this->QMM_Attach = other.QMM_Attach;
+    this->QMM_Detach = other.QMM_Detach;
+    this->QMM_vmMain = other.QMM_vmMain;
+    this->QMM_vmMain_Post = other.QMM_vmMain_Post;
+    this->QMM_syscall = other.QMM_syscall;
+    this->QMM_syscall_Post = other.QMM_syscall_Post;
+    this->QMM_PluginMessage = other.QMM_PluginMessage;
+    this->QMM_QVMHandler = other.QMM_QVMHandler;
+    this->plugininfo = other.plugininfo;
+
+    return *this;
+}
+
+
+int Plugin::Load(std::string file) {
+    // if this plugin somehow already has a dll pointer, cancel
+    if (this->dll)
+        return 0;
 
     // load DLL
-    if (!(p.dll = dll_load(file.c_str()))) {
+    if (!(this->dll = dll_load(file.c_str()))) {
         QMMLOG(QMM_LOG_ERROR, "QMM") << "plugin_load(\"" << file << "\"): DLL load failed for plugin: " << dll_error() << "\n";
-        goto fail;
+        return 0;
     }
 
     // if this DLL is the same as QMM, cancel
-    if ((void*)p.dll == gameinfo.qmm_module_ptr) {
+    if (this->dll == gameinfo.qmm_module_ptr) {
         QMMLOG(QMM_LOG_ERROR, "QMM") << "plugin_load(\"" << path_basename(file) << "\"): DLL is actually QMM?\n";
         // treat this failure specially. this is a valid DLL, but it is QMM
-        ret = -1;
-        goto fail;
+        return -1;
     }
 
     // if this DLL is the same as another loaded plugin, cancel
     for (Plugin& t : g_plugins) {
-        if (p.dll == t.dll) {
+        if (this->dll == t.dll) {
             QMMLOG(QMM_LOG_ERROR, "QMM") << "plugin_load(\"" << path_basename(file) << "\"): DLL is already loaded as plugin\n";
             // treat this failure specially. this is a valid plugin, but it is already loaded
-            ret = -1;
-            goto fail;
+            return -1;
         }
     }
 
-    if (!(p.QMM_Query = (Plugin::plugin_query)dll_symbol(p.dll, "QMM_Query"))) {
+    if (!(this->QMM_Query = (Plugin::plugin_query)dll_symbol(this->dll, "QMM_Query"))) {
         QMMLOG(QMM_LOG_ERROR, "QMM") << "plugin_load(\"" << path_basename(file) << "\"): Unable to find \"QMM_Query\" function\n";
-        goto fail;
+        return 0;
     }
 
     // call initial plugin entry point, get interface version
-    p.QMM_Query(&p.plugininfo);
-    if (!p.plugininfo) {
+    this->QMM_Query(&this->plugininfo);
+    if (!this->plugininfo) {
         QMMLOG(QMM_LOG_ERROR, "QMM") << "plugin_load(\"" << path_basename(file) << "\"): QMM_Query() returned NULL Plugininfo\n";
-        goto fail;
+        return 0;
     }
 
-    // if the plugin's major interface version is very high, it is likely an old plugin (pifv < 3:0) and it's actually the name string pointer
-    // so we can just grab the pifv values from reserved1 and reserved2 (the old slots) and let the next checks handle it
-    if (p.plugininfo->pifv_major > 999) {
-        p.plugininfo->pifv_major = p.plugininfo->reserved1;
-        p.plugininfo->pifv_minor = p.plugininfo->reserved2;
+    // if the plugin's major interface version is very high, it is likely an old plugin (pifv < 3:0) and it's actually
+    // the name string pointer, so we can just grab the pifv values from reserved1 and reserved2 (the old slots) and
+    // let the next checks handle it
+    if (this->plugininfo->pifv_major > 999) {
+        this->plugininfo->pifv_major = this->plugininfo->reserved1;
+        this->plugininfo->pifv_minor = this->plugininfo->reserved2;
     }
 
     // if the plugin's major interface version is lower, don't load and suggest to upgrade plugin
-    if (p.plugininfo->pifv_major < QMM_PIFV_MAJOR) {
-        QMMLOG(QMM_LOG_ERROR, "QMM") << "plugin_load(\"" << path_basename(file) << "\"): Plugin's interface version (" << p.plugininfo->pifv_major << ":" << p.plugininfo->pifv_minor << ") is less than QMM's (" STRINGIFY(QMM_PIFV_MAJOR) ":" STRINGIFY(QMM_PIFV_MINOR) "), suggest upgrading plugin.\n";
-        goto fail;
+    if (this->plugininfo->pifv_major < QMM_PIFV_MAJOR) {
+        QMMLOG(QMM_LOG_ERROR, "QMM") << "plugin_load(\"" << path_basename(file) << "\"): Plugin's interface version (" << this->plugininfo->pifv_major << ":" << this->plugininfo->pifv_minor << ") is less than QMM's (" STRINGIFY(QMM_PIFV_MAJOR) ":" STRINGIFY(QMM_PIFV_MINOR) "), suggest upgrading plugin.\n";
+        return 0;
     }
     // if the plugin's interface version is higher, don't load and suggest to upgrade QMM
-    else if (p.plugininfo->pifv_major > QMM_PIFV_MAJOR || p.plugininfo->pifv_minor > QMM_PIFV_MINOR) {
-        QMMLOG(QMM_LOG_ERROR, "QMM") << "plugin_load(\"" << path_basename(file) << "\"): Plugin's interface version (" << p.plugininfo->pifv_major << ":" << p.plugininfo->pifv_minor << ") is greater than QMM's (" STRINGIFY(QMM_PIFV_MAJOR) ":" STRINGIFY(QMM_PIFV_MINOR) "), suggest upgrading QMM.\n";
-        goto fail;
+    else if (this->plugininfo->pifv_major > QMM_PIFV_MAJOR || this->plugininfo->pifv_minor > QMM_PIFV_MINOR) {
+        QMMLOG(QMM_LOG_ERROR, "QMM") << "plugin_load(\"" << path_basename(file) << "\"): Plugin's interface version (" << this->plugininfo->pifv_major << ":" << this->plugininfo->pifv_minor << ") is greater than QMM's (" STRINGIFY(QMM_PIFV_MAJOR) ":" STRINGIFY(QMM_PIFV_MINOR) "), suggest upgrading QMM.\n";
+        return 0;
     }
     // at this point, major versions match and the plugin's minor version is less than or equal to QMM's
 
     // find remaining QMM api functions or fail
-    if (!(p.QMM_Attach = (Plugin::plugin_attach)dll_symbol(p.dll, "QMM_Attach"))) {
+    if (!(this->QMM_Attach = (Plugin::plugin_attach)dll_symbol(this->dll, "QMM_Attach"))) {
         QMMLOG(QMM_LOG_ERROR, "QMM") << "plugin_load(\"" << path_basename(file) << "\"): Unable to find \"QMM_Attach\" function\n";
-        goto fail;
+        return 0;
     }
-    if (!(p.QMM_Detach = (Plugin::plugin_detach)dll_symbol(p.dll, "QMM_Detach"))) {
+    if (!(this->QMM_Detach = (Plugin::plugin_detach)dll_symbol(this->dll, "QMM_Detach"))) {
         QMMLOG(QMM_LOG_ERROR, "QMM") << "plugin_load(\"" << path_basename(file) << "\"): Unable to find \"QMM_Detach\" function\n";
-        goto fail;
+        return 0;
     }
 
     // find hook callback functions
-    if (!(p.QMM_vmMain = (Plugin::plugin_callback)dll_symbol(p.dll, "QMM_vmMain"))) {
+    if (!(this->QMM_vmMain = (Plugin::plugin_callback)dll_symbol(this->dll, "QMM_vmMain"))) {
         QMMLOG(QMM_LOG_ERROR, "QMM") << "plugin_load(\"" << path_basename(file) << "\"): Unable to find \"QMM_vmMain\" function\n";
-        goto fail;
+        return 0;
     }
-    if (!(p.QMM_syscall = (Plugin::plugin_callback)dll_symbol(p.dll, "QMM_syscall"))) {
+    if (!(this->QMM_syscall = (Plugin::plugin_callback)dll_symbol(this->dll, "QMM_syscall"))) {
         QMMLOG(QMM_LOG_ERROR, "QMM") << "plugin_load(\"" << path_basename(file) << "\"): Unable to find \"QMM_syscall\" function\n";
-        goto fail;
+        return 0;
     }
-    if (!(p.QMM_vmMain_Post = (Plugin::plugin_callback)dll_symbol(p.dll, "QMM_vmMain_Post"))) {
+    if (!(this->QMM_vmMain_Post = (Plugin::plugin_callback)dll_symbol(this->dll, "QMM_vmMain_Post"))) {
         QMMLOG(QMM_LOG_ERROR, "QMM") << "plugin_load(\"" << path_basename(file) << "\"): Unable to find \"QMM_vmMain_Post\" function\n";
-        goto fail;
+        return 0;
     }
-    if (!(p.QMM_syscall_Post = (Plugin::plugin_callback)dll_symbol(p.dll, "QMM_syscall_Post"))) {
+    if (!(this->QMM_syscall_Post = (Plugin::plugin_callback)dll_symbol(this->dll, "QMM_syscall_Post"))) {
         QMMLOG(QMM_LOG_ERROR, "QMM") << "plugin_load(\"" << path_basename(file) << "\"): Unable to find \"QMM_syscall_Post\" function\n";
-        goto fail;
+        return 0;
     }
-
-    // find optional plugin functions
-    p.QMM_PluginMessage = (Plugin::plugin_pluginmessage)dll_symbol(p.dll, "QMM_PluginMessage");
-    p.QMM_QVMHandler = (Plugin::plugin_qvmhandler)dll_symbol(p.dll, "QMM_QVMHandler");
 
     // set some pluginvars only available at run-time (this will get repeated for every plugin, but that's ok)
-    s_pluginvars.vmbase = g_mod.vmbase;
+    s_pluginvars.vmbase = (intptr_t)g_mod.vm.memory;
 
-    // call QMM_Attach. if it fails (returns 0), call QMM_Detach and unload DLL
+    // call QMM_Attach. if it fails (returns 0), destructor will call QMM_Detach and unload DLL
     // QMM_Attach(engine syscall, mod vmmain, pointer to plugin result int, table of plugin helper functions, table of plugin variables)
-    if (!(p.QMM_Attach(s_plugin_game_syscall, s_plugin_game_vmMain, &g_plugin_globals.plugin_result, &s_pluginfuncs, &s_pluginvars))) {
+    if (!(this->QMM_Attach(s_plugin_game_syscall, s_plugin_game_vmMain, &g_plugin_globals.plugin_result, &s_pluginfuncs, &s_pluginvars))) {
         QMMLOG(QMM_LOG_ERROR, "QMM") << "plugin_load(\"" << path_basename(file) << "\"): QMM_Attach() returned 0\n";
         // treat this failure specially. this is a valid plugin, but it decided on its own that it shouldn't be loaded
-        ret = -1;
-        goto fail;
+        return -1;
     }
 
-    p.path = file;
-    ret = 1;
-    return ret;
+    this->path = file;
+    this->QMM_PluginMessage = (Plugin::plugin_pluginmessage)dll_symbol(this->dll, "QMM_PluginMessage");
+    this->QMM_QVMHandler = (Plugin::plugin_qvmhandler)dll_symbol(this->dll, "QMM_QVMHandler");
 
-fail:
-    plugin_unload(p);
-    return ret;
+    return 1;
 }
 
 
-void plugin_unload(Plugin& p) {
-    if (p.dll) {
-        if (p.QMM_Detach)
-            p.QMM_Detach();
-        dll_close(p.dll);
+void Plugin::Unload() {
+    if (this->dll) {
+        if (this->QMM_Detach)
+            this->QMM_Detach();
+        dll_close(this->dll);
     }
+    this->dll = nullptr;
+    this->path.clear();
+    this->QMM_Query = nullptr;
+    this->QMM_Attach = nullptr;
+    this->QMM_Detach = nullptr;
+    this->QMM_vmMain = nullptr;
+    this->QMM_vmMain_Post = nullptr;
+    this->QMM_syscall = nullptr;
+    this->QMM_syscall_Post = nullptr;
+    this->QMM_PluginMessage = nullptr;
+    this->QMM_QVMHandler = nullptr;
+    this->plugininfo = nullptr;
+}
 
-    p = Plugin();
+
+const char* Plugin::plugin_result_to_str(plugin_res res) {
+    switch (res) {
+        GEN_CASE(QMM_UNUSED);
+        GEN_CASE(QMM_ERROR);
+        GEN_CASE(QMM_IGNORED);
+        GEN_CASE(QMM_OVERRIDE);
+        GEN_CASE(QMM_SUPERCEDE);
+    default:
+        return "unknown";
+    };
 }
 
 
@@ -334,7 +375,7 @@ static char* s_plugin_helper_VarArgs(plugin_id plid [[maybe_unused]], const char
 * @return 0 if the mod is not a QVM, !0 otherwise
 */
 static int s_plugin_helper_IsQVM(plugin_id plid [[maybe_unused]]) {
-    int ret = g_mod.vmbase != 0;
+    int ret = !!g_mod.vm.memory;
 
     QMMLOG(QMM_LOG_TRACE, "QMM") << "Plugin \"" << ((plugin_info*)plid)->name << " called IsQVM() = " << ret << "\n";
 

--- a/src/qvm.c
+++ b/src/qvm.c
@@ -28,9 +28,47 @@ enum { QMM_LOG_TRACE, QMM_LOG_DEBUG, QMM_LOG_INFO, QMM_LOG_NOTICE, QMM_LOG_WARNI
 #endif
 
 
+void qvm_init(qvm* vm) {
+    if (!vm)
+        return;
+
+    vm->magic = 0;
+
+    vm->syscall = NULL;
+
+    vm->memory = NULL;
+    vm->memorysize = 0;
+
+    vm->codesegment = NULL;
+    vm->datasegment = NULL;
+    
+    vm->instructioncount = 0;
+    vm->codeseglen = 0;
+    vm->dataseglen = 0;
+
+    vm->stacksize = 0;
+    vm->stacklow = NULL;
+    vm->stackhigh = NULL;
+
+    vm->hunksize = 0;
+    vm->hunklow = 0;
+    vm->hunkhigh = 0;
+
+    vm->stackptr = NULL;
+    vm->hunkptr = 0;
+
+    vm->filesize = 0;
+    vm->allocator = NULL;
+    vm->verify_data = 0;
+}
+
+
 int qvm_load(qvm* vm, const uint8_t* filemem, size_t filesize, qvm_syscall qvmsyscall, int verify_data, size_t hunk_size, qvm_alloc* allocator) {
     if (!vm || vm->memory || !filemem || !filesize || !qvmsyscall)
         return 0;
+
+    // start fresh
+    qvm_init(vm);
 
     if (filesize < sizeof(qvm_header)) {
         log_c(QMM_LOG_ERROR, QMM_LOGGING_TAG, "qvm_load(): Invalid QVM file: too small for header\n");
@@ -230,13 +268,13 @@ fail:
 }
 
 
-static qvm qvm_empty;
 void qvm_unload(qvm* vm) {
     if (!vm)
         return;
     if (vm->memory)
         vm->allocator->free(vm->memory, vm->memorysize, vm->allocator->ctx);
-    *vm = qvm_empty;
+    vm->memory = NULL;
+    qvm_init(vm);
 }
 
 


### PR DESCRIPTION
Use RAII/OOP architecture to avoid requiring "goto fail" in mod and plugin loading code.